### PR TITLE
ajuste-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,12 +68,12 @@ COPY docker/php/custom.ini /usr/local/etc/php/conf.d/custom.ini
 
 
 
-# Use a imagem base desejada, por exemplo:
-    FROM php:7.4
+## Use a imagem base desejada, por exemplo:
+    # FROM php:7.4
 
-    # Copie o Makefile para o diretório /app do contêiner
-    COPY Makefile /app/Makefile
-    
-    # Defina o diretório de trabalho como /app
-    WORKDIR /app
-    
+    ## Copie o Makefile para o diretório /app do contêiner
+    # COPY Makefile /app/Makefile
+
+    ## Defina o diretório de trabalho como /app
+    #WORKDIR /app
+


### PR DESCRIPTION
Trecho do arquivos dockerfile foi comentado.
Esse trecho de código foi inserido pelo colega @Mendes113, para  algum problema específico.

Aqui no meu PC, rodou de boa mesmo com essas linhas adicionais.

Mas para evitar o problema aos demais da equipe, comentei o seguinte trecho, caso precisar dessa parte, basta descomentar e subir localhost e **não subir para o repositório**:

`## Use a imagem base desejada, por exemplo:
    # FROM php:7.4

    ## Copie o Makefile para o diretório /app do contêiner
    # COPY Makefile /app/Makefile

    ## Defina o diretório de trabalho como /app
    #WORKDIR /app
`