### PR TITLE
Feature/develop string search planning

### DIFF
--- a/app/Http/Controllers/Project/Planning/Overall/OverallController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/OverallController.php
@@ -34,16 +34,27 @@ class OverallController extends Controller
         $projectDomains = Domain::where('id_project', $id_project)->get();
         $projectKeywords = Keyword::where('id_project', $id_project)->get();
 
-        return view('project.planning.index', compact(
-            'id_project',
-            'project',
-            'projectDomains',
-            'projectKeywords',
-            'databases',
-            'languages',
-            'studyTypes',
-            'questionTypes',
-            'usersRelation',
-        ));
+        // Retrieve search-string
+        $terms = $project->terms;
+        $synonyms = $project->synonyms;
+        $searchStrings = []; // simulating the search string results
+
+        return view(
+            'project.planning.index',
+            compact(
+                'id_project',
+                'project',
+                'projectDomains',
+                'projectKeywords',
+                'databases',
+                'languages',
+                'studyTypes',
+                'questionTypes',
+                'usersRelation',
+                'terms',
+                'synonyms',
+                'searchStrings',
+            )
+        );
     }
 }

--- a/app/Http/Controllers/Project/Planning/SearchStringController.php
+++ b/app/Http/Controllers/Project/Planning/SearchStringController.php
@@ -47,7 +47,7 @@ class SearchStringController extends Controller
 
         $searchStrings = $this->getSearchStrings($id_project);
 
-        return view('search-string', compact('project', 'terms', 'synonyms', 'searchStrings'));
+        return view('project.planning.search-string', compact('project', 'terms', 'synonyms', 'searchStrings'));
     }
 
     /**

--- a/resources/views/project/planning/index.blade.php
+++ b/resources/views/project/planning/index.blade.php
@@ -74,7 +74,7 @@
                             @livewire("planning.databases.databases")
                         </div>
                         <div class="tab-pane fade" id="search-string">
-                            [wip]
+                            @//include("project.planning.search-string")
                         </div>
                         <div class="tab-pane fade" id="search-strategy">
                             @include("project.planning.search-strategy")

--- a/resources/views/project/planning/index.blade.php
+++ b/resources/views/project/planning/index.blade.php
@@ -74,7 +74,7 @@
                             @livewire("planning.databases.databases")
                         </div>
                         <div class="tab-pane fade" id="search-string">
-                            @//include("project.planning.search-string")
+                            @include("project.planning.search-string")
                         </div>
                         <div class="tab-pane fade" id="search-strategy">
                             @include("project.planning.search-strategy")

--- a/resources/views/project/planning/search-string.blade.php
+++ b/resources/views/project/planning/search-string.blade.php
@@ -6,7 +6,7 @@
                     <div class="card-header pb-0">
                         <h5 class="d-inline">Search String</h5>
                         <button type="button" class="bg-gradient-warning mb-3 help-thoth-button" data-bs-toggle="modal"
-                            data-bs-target="#modal-notification-3">?</button>
+                                data-bs-target="#modal-notification-3">?</button>
                         @component('partials.help-modal', ['modalId' => 'modal-notification-3', 'title' => 'Help Search String'])
                             <h4 class="text-black mt-4">The terms help to focus your search
                                 appropriately, looking for items that have had a specific term
@@ -18,18 +18,18 @@
                     <div class="card-body pb-0">
                         {{-- add term --}}
                         <form role="form" method="POST"
-                            action="{{ route('planning_search_string.add_term', $project->id_project) }}"
-                            style="display: flex;">
+                              action="{{ route('planning_search_string.add_term', $project->id_project) }}"
+                              style="display: flex;">
                             @csrf
                             <div class="col-md-5">
                                 <label for="descriptionTermInput" class="form-control-label">Term</label>
                                 <div class="form-group d-flex justify-content-between">
                                     <div class="col-sm-9">
                                         <input class="form-control" type="text" name="description_term"
-                                            id="descriptionTermInput" placeholder="Enter the term" required>
+                                               id="descriptionTermInput" placeholder="Enter the term" required>
                                     </div>
                                     <button type="submit" class="btn btn-primary ps-4 pe-4 py-1 px-2 mt-1"
-                                        id="addTermButton">Add</button>
+                                            id="addTermButton">Add</button>
                                 </div>
                             </div>
                         </form>
@@ -41,7 +41,7 @@
                     <div class="card-header pt-2 pb-0">
                         <h5 class="d-inline">Synonym</h5>
                         <button type="button" class="bg-gradient-warning mb-3 help-thoth-button" data-bs-toggle="modal"
-                            data-bs-target="#modal-notification-4">?</button>
+                                data-bs-target="#modal-notification-4">?</button>
                         @component('partials.help-modal', ['modalId' => 'modal-notification-4', 'title' => 'Help Synonym'])
                             <h4 class="text-black mt-4">Synonyms help searching for articles
                                 that use a different word for the same meaning as the term we
@@ -52,14 +52,14 @@
                         <div class="row align-content-center">
                             {{-- add synonym --}}
                             <form role="form" method="POST"
-                                action="{{ route('planning_search_string.add_synonym', $project->id_project) }}"
-                                style="display: flex;">
+                                  action="{{ route('planning_search_string.add_synonym', $project->id_project) }}"
+                                  style="display: flex;">
                                 @csrf
                                 <div class="col-md-5">
                                     <div class="col-auto">
                                         <label for="termSelect" class="form-control-label">Term</label>
                                         <select class="form-select" id="termSelect" name="termSelect" required
-                                            onchange="related_terms(this.value);">
+                                                onchange="related_terms(this.value);">
                                             <option value="" disabled selected>Select
                                                 a Term</option>
                                             @forelse ($terms as $term)
@@ -73,20 +73,19 @@
                                     </div>
                                 </div>
                                 <div class="col-md-5 text-start">
-                                    <label for="termSelect" class="form-control-label">Synonym</label>
+                                    <label for="descriptionSynonymInput" class="form-control-label">Synonym</label>
                                     <div class="form-group d-flex justify-content-between">
                                         <div class="col-sm-9">
                                             <input class="form-control" type="text" name="description_synonym"
-                                                id="descriptionSynonymInput" placeholder="Enter a synonym" required>
+                                                   id="descriptionSynonymInput" placeholder="Enter a synonym" required>
                                         </div>
                                         <button type="submit" class="btn btn-primary ps-4 pe-4 py-1 px-2 mt-1"
-                                            id="addSynonymButton">Add</button>
+                                                id="addSynonymButton">Add</button>
                                     </div>
                                 </div>
-
                             </form>
                             <div class="" id="related-terms">
-
+                                <!-- Placeholder for related terms -->
                             </div>
                             {{-- end synonym --}}
                         </div>
@@ -96,104 +95,96 @@
                 <div class="mt-4">
                     <div class="table-responsive m-4 card shadow-none border">
                         <table class="table align-items-center mb-0">
-                            {{-- <caption class="ps-2 mb-1 mt-3">List of Term</caption> --}}
                             <thead>
-                                <tr>
-                                    <th class="ps-5">Term</th>
-                                    <th>Synonyms</th>
-                                    <th class="text-center">Actions</th>
-                                </tr>
+                            <tr>
+                                <th class="ps-5">Term</th>
+                                <th>Synonyms</th>
+                                <th class="text-center">Actions</th>
+                            </tr>
                             </thead>
                             <tbody>
-                                @forelse ($terms as $term)
-                                    <tr>
-                                        <td class="ps-5">{{ $term->description }}</td>
-                                        <td>
-                                            <table class="table">
-                                                <tbody>
-                                                    @forelse ($term->synonyms as $synonym)
-                                                        <tr>
-                                                            <td class="text-center">{{ $synonym->description }}
-                                                            </td>
-                                                            <td>
-                                                                <div class="d-flex justify-content-end">
-                                                                    <a href="#"
-                                                                        class="btn btn-link text-secondary mt-2 pt-1 pb-1 mt-3"
-                                                                        data-bs-toggle="modal"
-                                                                        data-bs-target="#exampleModalMessage{{ $term->id_term }}_{{ $synonym->id_synonym }}"
-                                                                        data-original-title="Edit Synonym">Edit</a>
-                                                                    <!-- Synonym Edit Modal -->
-                                                                    @component('partials.synonym-modal', ['term' => $term, 'synonym' => $synonym])
-                                                                    @endcomponent
+                            @forelse ($terms as $term)
+                                <tr>
+                                    <td class="ps-5">{{ $term->description }}</td>
+                                    <td>
+                                        <table class="table">
+                                            <tbody>
+                                            @forelse ($term->synonyms as $synonym)
+                                                <tr>
+                                                    <td class="text-center">{{ $synonym->description }}</td>
+                                                    <td>
+                                                        <div class="d-flex justify-content-end">
+                                                            <a href="#"
+                                                               class="btn btn-link text-secondary mt-2 pt-1 pb-1 mt-3"
+                                                               data-bs-toggle="modal"
+                                                               data-bs-target="#exampleModalMessage{{ $term->id_term }}_{{ $synonym->id_synonym }}"
+                                                               data-original-title="Edit Synonym">Edit</a>
+                                                            <!-- Synonym Edit Modal -->
+                                                            @component('partials.synonym-modal', ['term' => $term, 'synonym' => $synonym])
+                                                            @endcomponent
 
-                                                                    <a href="#"
-                                                                        class="btn btn-link text-danger mt-2 pt-1 pb-1 mt-3"
-                                                                        data-bs-toggle="modal"
-                                                                        data-bs-target="#modal-delete-{{ $term->id_term }}_{{ $synonym->id_synonym }}">Delete</a>
-                                                                    <!-- Synonym Delete Modal -->
-                                                                    @component('partials.synonym-delete-modal', ['term' => $term, 'synonym' => $synonym])
-                                                                    @endcomponent
-                                                                </div>
-                                                            </td>
-                                                        </tr>
-                                                    @empty
-                                                        <tr>
-                                                            <td colspan="2">No synonyms
-                                                                added</td>
-                                                        </tr>
-                                                    @endforelse
-                                                </tbody>
-                                            </table>
-                                        </td>
-                                        <td>
-                                            <div class="d-flex justify-content-center">
-                                                <a href="#"
-                                                    class="btn btn-link text-secondary mt-2 pt-1 pb-1 mt-3"
-                                                    data-bs-toggle="modal"
-                                                    data-bs-target="#exampleModalMessage{{ $term->id_term }}"
-                                                    data-original-title="Edit Term">Edit</a>
-                                                <!-- Term Edit Modal -->
-                                                @component('partials.term-modal', ['term' => $term])
-                                                @endcomponent
+                                                            <a href="#"
+                                                               class="btn btn-link text-danger mt-2 pt-1 pb-1 mt-3"
+                                                               data-bs-toggle="modal"
+                                                               data-bs-target="#modal-delete-{{ $term->id_term }}_{{ $synonym->id_synonym }}">Delete</a>
+                                                            <!-- Synonym Delete Modal -->
+                                                            @component('partials.synonym-delete-modal', ['term' => $term, 'synonym' => $synonym])
+                                                            @endcomponent
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            @empty
+                                                <tr>
+                                                    <td colspan="2">No synonyms
+                                                        added</td>
+                                                </tr>
+                                            @endforelse
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                    <td>
+                                        <div class="d-flex justify-content-center">
+                                            <a href="#"
+                                               class="btn btn-link text-secondary mt-2 pt-1 pb-1 mt-3"
+                                               data-bs-toggle="modal"
+                                               data-bs-target="#exampleModalMessage{{ $term->id_term }}"
+                                               data-original-title="Edit Term">Edit</a>
+                                            <!-- Term Edit Modal -->
+                                            @component('partials.term-modal', ['term' => $term])
+                                            @endcomponent
 
-                                                <a href="#" class="btn btn-link text-danger mt-2 pt-1 pb-1 mt-3"
-                                                    data-bs-toggle="modal"
-                                                    data-bs-target="#modal-delete-{{ $term->id_term }}">Delete</a>
-                                                <!-- Term Delete Modal -->
-                                                @component('partials.term-delete-modal', ['term' => $term])
-                                                @endcomponent
-                                            </div>
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="3">No terms</td>
-                                    </tr>
-                                @endforelse
+                                            <a href="#" class="btn btn-link text-danger mt-2 pt-1 pb-1 mt-3"
+                                               data-bs-toggle="modal"
+                                               data-bs-target="#modal-delete-{{ $term->id_term }}">Delete</a>
+                                            <!-- Term Delete Modal -->
+                                            @component('partials.term-delete-modal', ['term' => $term])
+                                            @endcomponent
+                                        </div>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="3">No terms</td>
+                                </tr>
+                            @endforelse
                             </tbody>
                         </table>
                     </div>
                 </div>
                 <h6 class="ps-4 mt-2 mb-2"><strong><a href="#">String Improver</a></strong></h6>
-
                 <div id="strings">
                     <div class="form-inline">
                         <label><strong>Strings</strong></label>
                         <a onclick="modal_help('modal_help_strings')" class="float-right opt"><i
                                 class="fas fa-question-circle "></i></a>
                     </div>
-
                     @foreach ($searchStrings as $searchString)
                         <div class="form-group" id="div_string_{{ $searchString->database->name }}">
                             <a target="_blank" href="{{ $searchString->database->link }}">
                                 {{ $searchString->database->name }}
                             </a>
-                            <textarea class="form-control" name="generated_string" id="string_{{ $searchString->database->name }}">
-                                                                {{ $searchString->description }}
-                                                            </textarea>
-                            <form
-                                action="{{ route('generate-string', ['id_project' => $project->id_project, 'database_id' => 1]) }}"
-                                method="POST">
+                            <textarea class="form-control" name="generated_string" id="string_{{ $searchString->database->name }}">{{ $searchString->description }}</textarea>
+                            <form action="{{ route('generate-string', ['id_project' => $project->id_project, 'database_id' => 1]) }}" method="POST">
                                 @csrf
                                 <button type="submit" class="btn btn-info opt">Generate</button>
                             </form>
@@ -201,7 +192,6 @@
                         </div>
                     @endforeach
                 </div>
-
                 @include('components.prev-next')
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Project\conducting\OverallController as OverallConducti
 use App\Http\Controllers\Project\Planning\Overall\StudyTypeController;
 use App\Http\Controllers\Project\Planning\ResearchQuestionsController;
 use App\Http\Controllers\Project\Planning\SearchStrategyController;
+use App\Http\Controllers\Project\Planning\SearchStringController;
 use App\Http\Controllers\Project\Planning\DataExtraction\OptionController;
 use App\Http\Controllers\Project\Planning\DataExtraction\QuestionController;
 use App\Http\Controllers\Project\Planning\QualityAssessment\GeneralScoreController;
@@ -112,6 +113,17 @@ Route::prefix('/project/{projectId}')->group(function () {
         // Search Strategy Route
         Route::put('/search-strategy', [SearchStrategyController::class, 'update'])
             ->name('project.planning.search-strategy.update');
+
+        // Search String
+        Route::get('/search-string', [SearchStringController::class, 'index'])->name('search_string');
+        Route::post('/search-string/term/add', [SearchStringController::class, 'store_term'])->name('planning_search_string.add_term');
+        Route::post('/search-string/synonym/add', [SearchStringController::class, 'store_synonym'])->name('planning_search_string.add_synonym');
+        Route::post('/generate-string/{id_project}/{database_id}', [SearchStringController::class, 'generateString'])->name('generate-string');
+
+        Route::put('/search-string/term/{id}', [SearchStringController::class, 'update_term'])->name('planning_search_string.update_term');
+        Route::put('/search-string/synonym/{id}', [SearchStringController::class, 'update_synonym'])->name('planning_search_string.update_synonym');
+        Route::delete('/search-string/term/{id}', [SearchStringController::class, 'destroy_term'])->name('planning_search_string.destroy_term');
+        Route::delete('/search-string/synonym/{id}', [SearchStringController::class, 'destroy_synonym'])->name('planning_search_string.destroy_synonym');
 
         // Research Questions Routes
         Route::resource('/research-questions', ResearchQuestionsController::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,8 +116,8 @@ Route::prefix('/project/{projectId}')->group(function () {
 
         // Search String
         Route::get('/search-string', [SearchStringController::class, 'index'])->name('search_string');
-        Route::post('/search-string/term/add', [SearchStringController::class, 'store_term'])->name('planning_search_string.add_term');
-        Route::post('/search-string/synonym/add', [SearchStringController::class, 'store_synonym'])->name('planning_search_string.add_synonym');
+        Route::post('/search-string/term', [SearchStringController::class, 'store_term'])->name('planning_search_string.add_term');
+        Route::post('/search-string/synonym', [SearchStringController::class, 'store_synonym'])->name('planning_search_string.add_synonym');
         Route::post('/generate-string/{id_project}/{database_id}', [SearchStringController::class, 'generateString'])->name('generate-string');
 
         Route::put('/search-string/term/{id}', [SearchStringController::class, 'update_term'])->name('planning_search_string.update_term');


### PR DESCRIPTION
### Módulo Search String

Remover as barras nesse trecho do código  em "resources/views/project/planning/index.blade.php":
@//include("project.planning.search-string")

**Arquivos alterados e trazidos da branche antiga:**

- app/Http/Controllers/SearchStringController.php
- app/Models/Database.php
- app/Models/Project.php
- app/Models/ProjectDatabases.php
- app/Models/SearchString.php
- app/Models/SearchStringGeneric.php
- app/Models/Synonym.php
- app/Models/Term.php
- bootstrap/cache/services.php
- public/assets/js/search_string.js
- public/assets/js/terms.js
- resources/views/partials/synonym-delete-modal.blade.php
- resources/views/partials/synonym-modal.blade.php
- resources/views/partials/term-delete-modal.blade.php
- resources/views/partials/term-modal.blade.php
- resources/views/project/planning/index.blade.php
- resources/views/project/planning/search-string.blade.php

obs.: não foram todos alterados nessa PR.