### PR TITLE
fix(bug11): duplicate RQs and update button in english

### DIFF
--- a/app/Livewire/Planning/Questions/ResearchQuestions.php
+++ b/app/Livewire/Planning/Questions/ResearchQuestions.php
@@ -112,7 +112,30 @@ class ResearchQuestions extends Component
             $value = $this->form['isEditing'] ? 'Updated the research question' : 'Added a research question';
             $toastMessage = $this->message($this->form['isEditing'] ? '.updated' : '.added');
 
+            // CREATE verifications
             if (!$this->form['isEditing'] && $this->currentProject->researchQuestions->contains('id', $this->questionId)) {
+                $this->toast(
+                    message: 'This ID is already in use. Please choose a unique ID for the question.',
+                    type: 'error'
+                );
+                return;
+            }
+
+            if(!$this->form['isEditing'] && $this->currentProject->researchQuestions->contains('description', $this->description)) {
+                $this->toast(
+                    message: 'There cannot be duplicate research questions. Please consider changing the description of this research question.',
+                    type: 'error'
+                );
+                return;
+            }
+
+
+            // UPDATE verifications
+            if (
+                $this->form['isEditing']
+                && $this->currentQuestion->id != $this->questionId
+                && $this->currentProject->researchQuestions->contains('id', $this->questionId)
+            ) {
                 $this->toast(
                     message: 'This ID is already in use. Please choose a unique ID for the question.',
                     type: 'error'
@@ -122,11 +145,11 @@ class ResearchQuestions extends Component
 
             if (
                 $this->form['isEditing']
-                && $this->currentQuestion->id != $this->questionId
-                && $this->currentProject->researchQuestions->contains('id', $this->questionId)
+                && $this->currentQuestion->description != $this->description
+                && $this->currentProject->researchQuestions->contains('description', $this->description)
             ) {
                 $this->toast(
-                    message: 'This ID is already in use. Please choose a unique ID for the question.',
+                    message: 'There cannot be duplicate research questions. Please consider changing the description of this research question.',
                     type: 'error'
                 );
                 return;

--- a/lang/en/project/planning.php
+++ b/lang/en/project/planning.php
@@ -253,6 +253,7 @@ return [
             'description' => 'Description',
             'enter_description' => 'Enter research question description',
             'add' => 'Add',
+            'update' => 'Update',
         ],
         'table' => [
             'id' => 'ID',


### PR DESCRIPTION
This commit fixes bug 11 by preventing the system from allowing duplicate research questions (RQs) to be registered. Now, before saving a new RQ, the system checks for existing identical entries and blocks duplicates. Additionally, the RQ edit button in english has been setted.