### PR TITLE
feat: verifica caracteres especiais no ID da pergunta de extração

### DIFF
--- a/app/Livewire/Planning/DataExtraction/Question.php
+++ b/app/Livewire/Planning/DataExtraction/Question.php
@@ -35,21 +35,18 @@ class Question extends Component
     /**
      * Validation rules.
      */
-    protected $rules = [
-        'description' => 'required|string',
-        'type' => 'required|array',
-    ];
-
-    /**
-     * Custom error messages for the validation rules.
-     */
-    protected function messages()
+    public function rules()
     {
         return [
-            'description.required' => 'Este campo é obrigatório',
-            'type.required' => 'Este campo é obrigatório',
+            'questionId' => ['required', 'regex:/^[a-zA-Z0-9]+$/'],
+            'description' => 'required',
+            'type' => 'required'
         ];
     }
+
+    protected $messages = [
+        'questionId.regex' => 'O ID deve conter apenas letras e números.',
+    ];
 
     /**
      * Executed when the component is mounted. It sets the

--- a/resources/views/livewire/planning/data-extraction/question.blade.php
+++ b/resources/views/livewire/planning/data-extraction/question.blade.php
@@ -16,6 +16,7 @@
                     wire:model="questionId"
                     placeholder="Não utilize caracteres especiais"
                     maxlength="255"
+                    pattern="[a-zA-Z0-9]+"
                     required
                 />
                 @error("questionId")


### PR DESCRIPTION
Verificação a nível de frontend e backend que permite apenas números e letras no cadastro de IDs das perguntas de extração