### PR TITLE
feat: planning progress bar updates after changes (add/delete)

### DIFF
--- a/app/Http/Controllers/Project/Planning/CriteriaController.php
+++ b/app/Http/Controllers/Project/Planning/CriteriaController.php
@@ -56,10 +56,13 @@ class CriteriaController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'criteria')
-            ->with('success', 'Criteria added successfully');
+            ->with('success', 'Criteria added successfully')
+            ->with('progress', $progress);   
     }
 
 
@@ -126,10 +129,13 @@ class CriteriaController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'criteria')
-            ->with('success', 'Criteria deleted successfully');
+            ->with('success', 'Criteria deleted successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/DataExtraction/OptionController.php
+++ b/app/Http/Controllers/Project/Planning/DataExtraction/OptionController.php
@@ -61,9 +61,12 @@ class OptionController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-extraction')
+            ->with('progress', $progress)
             ->with('success', 'Option added successfully');
     }
 
@@ -113,11 +116,13 @@ class OptionController extends Controller
         );
 
         $option->delete();
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
 
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-extraction')
-            ->with('success', 'Question deleted successfully');
+            ->with('progress', $progress)
+            ->with('success', 'Option deleted successfully');
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/DataExtraction/QuestionController.php
+++ b/app/Http/Controllers/Project/Planning/DataExtraction/QuestionController.php
@@ -47,10 +47,13 @@ class QuestionController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-extraction')
-            ->with('success', 'Question added successfully');
+            ->with('success', 'Question added successfully')
+            ->with('progress', $progress);
     }
 
     /**
@@ -101,11 +104,13 @@ class QuestionController extends Controller
         );
 
         $question->delete();
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
 
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-extraction')
-            ->with('success', 'Question deleted successfully');
+            ->with('success', 'Question deleted successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/DatabaseController.php
+++ b/app/Http/Controllers/Project/Planning/DatabaseController.php
@@ -66,10 +66,13 @@ class DatabaseController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-bases')
-            ->with('success', 'Database added to the project');
+            ->with('success', 'Database added to the project')
+            ->with('progress', $progress);
     }
 
     /**
@@ -100,10 +103,13 @@ class DatabaseController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-bases')
-            ->with('success', 'Database removed from the project');
+            ->with('success', 'Database removed from the project')
+            ->with('progress', $progress);
     }
 
     /**
@@ -131,10 +137,13 @@ class DatabaseController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'data-bases')
-            ->with('success', 'Database Suggested successfully');
+            ->with('success', 'Database Suggested successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/Overall/DateController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/DateController.php
@@ -60,10 +60,13 @@ class DateController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Date added successfully');
+            ->with('success', 'Date added successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/Overall/DomainController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/DomainController.php
@@ -18,12 +18,20 @@ namespace App\Http\Controllers\Project\Planning\Overall;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\DomainUpdateRequest;
 use App\Models\Domain;
+use App\Http\Controllers\Project\Planning\PlanningProgressController;
 use App\Utils\ActivityLogHelper;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 
 class DomainController extends Controller
 {
+    private PlanningProgressController $progressCalculator;
+
+    public function __construct(PlanningProgressController $progressCalculator)
+    {
+        $this->progressCalculator = $progressCalculator;
+    }
+
     /**
      * Store a newly created domain.
      *
@@ -43,10 +51,13 @@ class DomainController extends Controller
             projectId: $request->id_project
         );
 
+        $progress = $this->progressCalculator->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Domain added successfully');
+            ->with('success', 'Domain added successfully')
+            ->with('progress', $progress);
     }
 
     /**
@@ -81,10 +92,13 @@ class DomainController extends Controller
             projectId: $projectId
         );
 
+        $progress = $this->progressCalculator->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Domain updated successfully');
+            ->with('success', 'Domain updated successfully')
+            ->with('progress', $progress);
     }
 
     /**
@@ -108,10 +122,13 @@ class DomainController extends Controller
             projectId: $projectId
         );
 
+        $progress = $this->progressCalculator->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Domain deleted successfully');
+            ->with('success', 'Domain deleted successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/Overall/KeywordController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/KeywordController.php
@@ -44,10 +44,13 @@ class KeywordController extends Controller
             id_project: $request->id_project
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Keyword added successfully');
+            ->with('success', 'Keyword added successfully')
+            ->with('progress', $progress);
     }
 
     /**
@@ -113,10 +116,13 @@ class KeywordController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Keyword deleted successfully');
+            ->with('success', 'Keyword deleted successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/Overall/LanguageController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/LanguageController.php
@@ -59,10 +59,13 @@ class LanguageController extends Controller
             id_project: $id_project
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($id_project);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Language added to the project');
+            ->with('success', 'Language added to the project')
+            ->with('progress', $progress);
     }
 
     /**
@@ -86,11 +89,14 @@ class LanguageController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Language removed from the project');
-    }
+            ->with('success', 'Language removed from the project')
+            ->with('progress', $progress);
+        }
 
     /**
      * Log activity for the specified language.

--- a/app/Http/Controllers/Project/Planning/Overall/StudyTypeController.php
+++ b/app/Http/Controllers/Project/Planning/Overall/StudyTypeController.php
@@ -59,10 +59,13 @@ class StudyTypeController extends Controller
             id_project: $id_project
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Study type added to the project');
+            ->with('success', 'Study type added to the project')
+            ->with('progress', $progress);
     }
 
     /**
@@ -86,10 +89,13 @@ class StudyTypeController extends Controller
             id_project: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'overall-info')
-            ->with('success', 'Study type removed from the project');
+            ->with('success', 'Study type removed from the project')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/PlanningProgressController.php
+++ b/app/Http/Controllers/Project/Planning/PlanningProgressController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Project\Planning;
+
+use App\Models\Domain;
+use App\Models\ProjectLanguage;
+use App\Models\ProjectStudyType;
+use App\Models\Keyword;
+use App\Models\Project;
+use App\Models\ResearchQuestion;
+use App\Models\Database;
+use App\Models\Term;
+use App\Models\Criteria;
+use App\Models\Project\Planning\QualityAssessment\Question;
+use App\Http\Requests\Project\Planning\DataExtraction\Question\StoreQuestionRequest;
+use App\Http\Requests\Project\Planning\DataExtraction\Question\UpdateQuestionRequest;
+use App\Models\Project\Planning\DataExtraction\Question as DataExtractionQuestionAlias;
+use Illuminate\Http\Request;
+
+class PlanningProgressController
+{
+    /**
+     * Calculate the overall planning progress.
+     *
+     * @param string $projectId
+     * @return array
+     */
+    public function calculate(string $projectId): array
+    {
+        $totalSections = 12; // Número total de seções no planejamento
+        $completedSections = 0;
+    
+        // Verificar se pelo menos um domínio foi adicionado
+        $planningProgress = Domain::where('id_project', $projectId)->exists() ? 1 : 0;
+        // Verificar se pelo menos uma lang foi selecionada
+        $languageProgress = ProjectLanguage::where('id_project', $projectId)->exists() ? 1 : 0;
+        // Verificar se pelo menos um estudo foi selecionado
+        $importStudiesProgress = ProjectStudyType::where('id_project', $projectId)->exists() ? 1 : 0;
+        $keywordProgress = Keyword::where('id_project', $projectId)->exists() ? 1 : 0;
+        
+        $dateProgress = Project::where('id_project', $projectId)
+        ->whereNotNull('start_date')
+        ->whereNotNull('end_date')
+        ->exists() ? 1 : 0;
+        
+        $researchQuestionProgress = ResearchQuestion::where('id_project', $projectId)->exists() ? 1 : 0;
+        
+        $databaseProgress = Database::whereHas('projects', function ($query) use ($projectId) {
+            $query->where('project_databases.id_project', $projectId);
+        })->exists() ? 1 : 0;
+        $termProgress = Term::where('id_project', $projectId)->exists() ? 1 : 0;
+
+        $searchStrategyProgress = Project::where('id_project', $projectId)
+        ->whereHas('searchStrategy', function ($query) {
+            $query->whereNotNull('description');
+        })->exists() ? 1 : 0;
+
+        $criteriaProgress = Criteria::where('id_project', $projectId)->exists() ? 1 : 0;
+        $qualityAssessmentProgress = DataExtractionQuestionAlias::where('id_project', $projectId)->exists() ? 1 : 0;
+        $questionProgress = Question::where('id_project', $projectId)->exists() ? 1 : 0;
+
+        // Calcular o número de seções preenchidas
+        $completedSections += $planningProgress;
+        $completedSections += $languageProgress;
+        $completedSections += $importStudiesProgress;
+        $completedSections += $keywordProgress;
+        $completedSections += $dateProgress;
+        $completedSections += $researchQuestionProgress;
+        $completedSections += $databaseProgress;
+        $completedSections += $termProgress;
+        $completedSections += $searchStrategyProgress;
+        $completedSections += $criteriaProgress;
+        $completedSections += $qualityAssessmentProgress;
+        $completedSections += $questionProgress;
+
+        // Calcular o progresso geral como uma porcentagem
+        $overallProgress = ($completedSections / $totalSections) * 100;
+    
+        return [
+            'overall' => $overallProgress, // Progresso geral
+            'planning' => ($planningProgress / $totalSections) * 100,
+            'languages' => ($languageProgress / $totalSections) * 100,
+            'importStudies' => ($importStudiesProgress / $totalSections) * 100,
+            'keywords' => ($keywordProgress / $totalSections) * 100,
+            'dates' => ($dateProgress / $totalSections) * 100,
+            'researchQuestions' => ($researchQuestionProgress / $totalSections) * 100,
+            'databases' => ($databaseProgress / $totalSections) * 100,
+            'terms' => ($termProgress / $totalSections) * 100,
+            'searchStrategy' => ($searchStrategyProgress / $totalSections) * 100,
+            'criteria' => ($criteriaProgress / $totalSections) * 100,
+            'qualityAssessment' => ($qualityAssessmentProgress / $totalSections) * 100,
+            'dataExtraction' => ($questionProgress / $totalSections) * 100,
+        ];
+    }
+}

--- a/app/Http/Controllers/Project/Planning/ResearchQuestionsController.php
+++ b/app/Http/Controllers/Project/Planning/ResearchQuestionsController.php
@@ -54,10 +54,13 @@ class ResearchQuestionsController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'research-questions')
-            ->with('success', 'Research question added successfully');
+            ->with('success', 'Research question added successfully')
+            ->with('progress', $progress);
     }
 
     /**
@@ -121,10 +124,13 @@ class ResearchQuestionsController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'research-questions')
-            ->with('success', 'Research question deleted successfully');
+            ->with('success', 'Research question deleted successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/SearchStrategyController.php
+++ b/app/Http/Controllers/Project/Planning/SearchStrategyController.php
@@ -44,10 +44,13 @@ class SearchStrategyController extends Controller
             projectId: $projectId
         );
 
+        $progress = app(PlanningProgressController::class)->calculate($projectId);
+
         return redirect()
             ->back()
             ->with('activePlanningTab', 'search-strategy')
-            ->with('success', 'Search Strategy updated successfully');
+            ->with('success', 'Search Strategy updated successfully')
+            ->with('progress', $progress);
     }
 
     /**

--- a/app/Http/Controllers/Project/Planning/SearchStringController.php
+++ b/app/Http/Controllers/Project/Planning/SearchStringController.php
@@ -61,7 +61,11 @@ class SearchStringController extends Controller
             'description' => $request->input('description_term'),
         ]);
 
-        return redirect("/planning/".$id_project."/search-string");
+        $progress = app(PlanningProgressController::class)->calculate($id_project);
+
+        return redirect("/planning/".$id_project."/search-string")
+            ->with('progress', $progress)
+            ->with('success', 'Term added successfully');
     }
 
     /**
@@ -88,7 +92,11 @@ class SearchStringController extends Controller
         $term->description = $request->input('term-description');
         $term->save();
 
-        return redirect()->back();
+        $progress = app(PlanningProgressController::class)->calculate($term->id_project);
+
+        return redirect()->back()
+            ->with('progress', $progress)
+            ->with('success', 'Term updated successfully');
     }
 
     /**
@@ -99,7 +107,11 @@ class SearchStringController extends Controller
         $term = Term::findOrFail($id_term);
         $term->delete();
 
-        return redirect()->back();
+        $progress = app(PlanningProgressController::class)->calculate($id_project);
+
+        return redirect()->back()
+            ->with('progress', $progress)
+            ->with('success', 'Term removed successfully');
     }
 
     /**

--- a/resources/views/projects/project-overview.blade.php
+++ b/resources/views/projects/project-overview.blade.php
@@ -45,11 +45,11 @@
                         </div>
                     </div>
                     <div class="progress">
-                        <div class="progress-bar bg-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0"
-                            aria-valuemax="100" style="width: 60%;"></div>
+                        <div class="progress-bar bg-primary" role="progressbar" aria-valuenow="{{ $progress['overall'] }}" aria-valuemin="0"
+                            aria-valuemax="100" style="width: {{ $progress['overall'] }}%;">
+                            {{ $progress['overall'] }}%
+                        </div>
                     </div>
-                </div>
-            </div>
             <div class="card-body">
                 <div class="progress-wrapper">
                     <div class="progress-info">


### PR DESCRIPTION
This commit resolves issue #319, implementing a feature update for the project planning progress bar, so that every time a new item (domain, for example) is added/deleted, the bar is updated and shows the total progression for the planning part of the project at that point.