### PR TITLE
fix: evita a entrada da letra E e outros caracteres

### DIFF
--- a/app/Livewire/Planning/QualityAssessment/QuestionRanges.php
+++ b/app/Livewire/Planning/QualityAssessment/QuestionRanges.php
@@ -80,6 +80,11 @@ class QuestionRanges extends Component
   public function updateMax($index, $value)
   {
     try {
+      // Validar se o valor é um número válido
+      if (!is_numeric($value)) {
+        throw new \Exception(__('project/planning.quality-assessment.ranges.invalid-number'));
+      }
+
       /**
        * If the new "end" value is the same as the current "end" value,
        * do nothing
@@ -88,8 +93,8 @@ class QuestionRanges extends Component
         return;
       }
 
-      $this->items[$index]['end'] = round($value, 2);
-      $this->items[$index + 1]['start'] = round($value + 0.01, 2);
+      $this->items[$index]['end'] = round((float)$value, 2);
+      $this->items[$index + 1]['start'] = round((float)$value + 0.01, 2);
 
       /**
        * Update the current "end" value
@@ -110,7 +115,7 @@ class QuestionRanges extends Component
       GeneralScore::updateOrCreate([
         'id_general_score' => $this->items[$index + 1]['id_general_score']
       ], [
-        'start' => round($value + 0.01, 2),
+        'start' => round((float)$value + 0.01, 2),
       ]);
 
         $this->dispatch('general-scores-generated');

--- a/resources/views/livewire/planning/quality-assessment/question-ranges.blade.php
+++ b/resources/views/livewire/planning/quality-assessment/question-ranges.blade.php
@@ -19,6 +19,7 @@
                         max="{{ $sum }}"
                         disabled="{{ !$loop->first }}"
                         style="min-width: 150px"
+                        x-on:keydown="['e', 'E', '+', '-'].includes($event.key) && $event.preventDefault()"
                     />
                     <x-input
                         label="Max"
@@ -30,6 +31,7 @@
                         max="{{ $sum }}"
                         style="min-width: 150px"
                         disabled="{{ $loop->last }}"
+                        x-on:keydown="['e', 'E', '+', '-'].includes($event.key) && $event.preventDefault()"
                     />
                     <div class="btn-group">
                         <x-input


### PR DESCRIPTION
Campos do tipo number proíbem a inserção de letras, com exceção da letra 'e' devido a algumas notações científicas. Isso ocasionava um erro de tipo em desenvolvimento e um erro 500 em produção, pois o backend interpretava como string. O mesmo ocorre para outros caracteres como '+' e '-'. Removi a possibilidade de utilizar estes caracteres a mais no frontend, pois estes campos não fazem uso deles, e adicionei validações no backend também.

Bug 42 na planilha