### PR TITLE
fix (bug 43): aspas duplas quebram as strings de aviso

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -198,8 +198,16 @@
                 const toastBody = toastElement.querySelector('.toast-body');
                 const toastTime = toastElement.querySelector('.toast-time');
 
+                function decodeHtmlEntities(str) {
+                    if (!str) return '';
+                    const temp = document.createElement('textarea');
+                    temp.innerHTML = str;
+                    return temp.value;
+                }
+
                 function showToast(message, type) {
-                    toastBody.innerText = message;
+                    const decodedMessage = decodeHtmlEntities(message);
+                    toastBody.innerText = decodedMessage;
                     toastElement.querySelector('.toast-header strong').innerText = type;
                     const toast = new bootstrap.Toast(toastElement);
                     toast.show();
@@ -220,7 +228,6 @@
                         showToast(validationErrors.join(' '), 'Error');
                     @endif
                 }
-
             });
         </script>
 

--- a/resources/views/project/conducting/index.blade.php
+++ b/resources/views/project/conducting/index.blade.php
@@ -16,10 +16,18 @@
                     @if (session()->has('error'))
                         <div class='card card-body col-md-12 mt-3'>
                             <h3 class="h5 mb-3">{{ __('project/conducting.study-selection.tasks') }}</h3>
-                            <div class="alert alert-warning">
+                            <div class="alert alert-warning" id="errorMessage">
                                 {{ session('error') }}
                             </div>
                         </div>
+                        <script>
+                            document.addEventListener('DOMContentLoaded', function() {
+                                const errorElement = document.getElementById('errorMessage');
+                                if (errorElement) {
+                                    errorElement.innerText = decodeHtmlEntities(errorElement.innerText);
+                                }
+                            });
+                        </script>
                     @else
                     @include(
                         "project.components.project-tabs",


### PR DESCRIPTION
Muitas mensagens de aviso exibidas nos toasts usam de aspas duplas dentro das aspas simples, o que acaba quebrando a exibição da string pois as aspas são interpretadas como sua representação textual, conforme mostra a iamgem:

![Captura de tela 2025-04-06 172637](https://github.com/user-attachments/assets/0e358ac0-132c-4e0c-b164-e95931adb615)

Adicionei uma função decodeHtmlEntities() que irá processar essas strings da forma correta antes da exibição, fazendo com que nenhum texto seja quebrado e sem que seja necessário alterar todos os avisos que usam aspas duplas.

![image](https://github.com/user-attachments/assets/06f1c12f-79b1-4848-859a-cbd2a7dc624b)
