### PR TITLE
fix(bug 39): Barra extra impede rolagem completa na tela de Critérios de Inclusão/Exclusão

### DIFF
--- a/public/assets/js/argon-dashboard.js
+++ b/public/assets/js/argon-dashboard.js
@@ -2221,7 +2221,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
     // if we are on windows OS we activate the perfectScrollbar function
     if (document.getElementsByClassName('main-content')[0]) {
       var mainpanel = document.querySelector('.main-content');
-      var ps = new PerfectScrollbar(mainpanel);
+      // var ps = new PerfectScrollbar(mainpanel);
     }
 
     ;


### PR DESCRIPTION
Ao tentar rolar a página na tela de Critérios de Inclusão/Exclusão surge uma segunda barra lateral que impede que todo o conteúdo seja visualizado pelo usuário. Segue evidência no link a seguir:

https://jam.dev/c/cc8f02e4-4d85-499b-abb3-50abce703141

Comentei a linha `var ps = new PerfectScrollbar(mainpanel);` no arquivo localizado em` public/assets/js/argon-dashboard.js`, pois o `PerfectScrollbar `forçava a criação de uma nova barra de rolagem personalizada no elemento `.main-content`, mesmo quando a rolagem natural do navegador já estava ativa, o que acabou gerando duas barras: uma nativa e uma falsa. Ao comentar a linha descrita, apenas a barra nativa do navegador foi utilizada e o usuário já consegue visualizar todo o conteúdo contido na página sem transtornos.