### PR TITLE
fix(bug 44): Modificação do ícone para deslogar e adição de notação textual para dispositivos móveis

### DIFF
--- a/resources/views/layouts/navbars/auth/topnav.blade.php
+++ b/resources/views/layouts/navbars/auth/topnav.blade.php
@@ -27,8 +27,8 @@
                         <a href="{{ route('logout') }}"
                             onclick="event.preventDefault(); document.getElementById('logout-form').submit();"
                             class="nav-link text-white font-weight-bold px-0">
-                            <i class="fa fa-user me-sm-1"></i>
-                            <span class="d-sm-inline d-none">{{ __('nav/nav.logout') }}</span>
+                            <i class="fa fa-sign-out-alt me-ms-1"></i>
+                            <span>{{ __('nav/nav.logout') }}</span>
                         </a>
                     </form>
                 </li>

--- a/resources/views/layouts/navbars/guest/navbar.blade.php
+++ b/resources/views/layouts/navbars/guest/navbar.blade.php
@@ -133,10 +133,10 @@
                                             class="nav-link d-flex align-items-center justify-content-center me-1"
                                         >
                                             <i
-                                                class="fa fa-user opacity-6 me-1"
+                                                class="fa fa-sign-out-alt me-1 text-secondary"
                                             ></i>
-                                            <span class="d-sm-inline d-none">
-                                            {{ __("nav/nav.logout") }}
+                                            <span>
+                                                {{ __('nav/nav.logout') }}
                                             </span>
                                         </a>
                                     </form>


### PR DESCRIPTION
Ao acessar a plataforma por meio de um dispositivo móvel, analisou-se que a opção de deslogar não exibia uma notação textual que auxiliasse na identificação da funcionalidade. Em vez disso, era exibido apenas um ícone de perfil, o que dificultava a compreensão do usuário, já que esse ícone é comumente associado ao acesso às informações de perfil do usuário,  como demonstrado nas imagens a seguir:

![Captura de tela 2025-04-06 192553](https://github.com/user-attachments/assets/400209ea-4686-4225-94c1-aca66796635f)

![Captura de tela 2025-04-06 192612](https://github.com/user-attachments/assets/38961fcb-7443-4218-95e1-fac512b2f435)


A fim de eliminar essa ambiguidade, modifiquei o ícone do logout e adicionei uma notação textual de apoio para o usuário compreender a qual funcionalidade este ícone se refere:

![Captura de tela 2025-04-06 192634](https://github.com/user-attachments/assets/912957d7-ed8b-4539-9e18-8d0f38072c1d)

![Captura de tela 2025-04-06 192649](https://github.com/user-attachments/assets/a2d761d6-0498-4336-9a9a-acb9706c7d93)
