### PR TITLE
fix(bug01): Crash in export button without papers, fix(bug03) Add Question Option with question undefinded

### DIFF
--- a/app/Livewire/Conducting/QualityAssessment/Buttons.php
+++ b/app/Livewire/Conducting/QualityAssessment/Buttons.php
@@ -17,14 +17,39 @@ use App\Utils\ToastHelper;
 class Buttons extends Component
 {
 
+    private $translationPath = 'project/conducting.data-extraction.buttons';
+    private $toastMessages = 'project/conducting.data-extraction.buttons';
+
     public $projectId;
 
+
+    protected function messages()
+    {
+        return [
+            'no-papers' => __($this->translationPath . '.no-papers'),
+        ];
+    }
+
+    public function toast(string $message, string $type)
+    {
+        $this->dispatch('buttons', ToastHelper::dispatch($type, $message));
+    }
 
     public function exportCsv()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $csvData = $this->formatCsv($papers);
-        return response()->streamDownload(function() use ($csvData) {
+        return response()->streamDownload(function () use ($csvData) {
             echo $csvData;
         }, 'studies-qa.csv');
     }
@@ -32,8 +57,18 @@ class Buttons extends Component
     public function exportXml()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $xmlData = $this->formatXml($papers);
-        return response()->streamDownload(function() use ($xmlData) {
+        return response()->streamDownload(function () use ($xmlData) {
             echo $xmlData;
         }, 'studies-qa.xml');
     }
@@ -42,8 +77,18 @@ class Buttons extends Component
     {
 
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+        
         $pdfData = $this->formatPdf($papers);
-        return response()->streamDownload(function() use ($pdfData) {
+        return response()->streamDownload(function () use ($pdfData) {
             echo $pdfData;
         }, 'studies-qa.pdf');
     }
@@ -70,7 +115,8 @@ class Buttons extends Component
             ->join('members', 'members.id_members', '=', 'papers_qa.id_member')
             ->join('users', 'members.id_user', '=', 'users.id')
             ->join('papers_selection', 'papers_selection.id_paper', '=', 'papers_qa.id_paper')
-            ->select('papers.*',
+            ->select(
+                'papers.*',
                 'papers.id as id_paper',
                 'data_base.name as database_name',
                 'general_score.description as general_score',
@@ -78,9 +124,10 @@ class Buttons extends Component
                 'users.firstname',
                 'users.lastname',
                 'paper_decision_conflicts.new_status_paper',
-                'status_qa.status as status_description')
+                'status_qa.status as status_description'
+            )
 
-            ->leftJoin('paper_decision_conflicts', function($join) {
+            ->leftJoin('paper_decision_conflicts', function ($join) {
                 $join->on('papers.id_paper', '=', 'paper_decision_conflicts.id_paper')
                     ->where('paper_decision_conflicts.phase', '=', 'quality'); // Filtrar pela fase 'quality'
             })
@@ -173,7 +220,8 @@ class Buttons extends Component
     }
 
 
-    public function mount() {
+    public function mount()
+    {
         $this->projectId = request()->segment(2);
     }
 

--- a/app/Livewire/Conducting/Snowballing/Buttons.php
+++ b/app/Livewire/Conducting/Snowballing/Buttons.php
@@ -16,12 +16,38 @@ use App\Utils\ToastHelper;
 class Buttons extends Component
 {
 
+    private $translationPath = 'project/conducting.data-extraction.buttons';
+    private $toastMessages = 'project/conducting.data-extraction.buttons';
+
     public $projectId;
+
+
+    protected function messages()
+    {
+        return [
+            'no-papers' => __($this->translationPath . '.no-papers'),
+        ];
+    }
+
+    public function toast(string $message, string $type)
+    {
+        $this->dispatch('buttons', ToastHelper::dispatch($type, $message));
+    }
 
 
     public function exportCsv()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $csvData = $this->formatCsv($papers);
         return response()->streamDownload(function() use ($csvData) {
             echo $csvData;
@@ -31,6 +57,16 @@ class Buttons extends Component
     public function exportXml()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+        
         $xmlData = $this->formatXml($papers);
         return response()->streamDownload(function() use ($xmlData) {
             echo $xmlData;
@@ -41,6 +77,16 @@ class Buttons extends Component
     {
 
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $pdfData = $this->formatPdf($papers);
         return response()->streamDownload(function() use ($pdfData) {
             echo $pdfData;

--- a/app/Livewire/Conducting/StudySelection/Buttons.php
+++ b/app/Livewire/Conducting/StudySelection/Buttons.php
@@ -17,12 +17,23 @@ use App\Utils\ToastHelper;
 
 class Buttons extends Component
 {
+    
+    private $translationPath = 'project/conducting.data-extraction.buttons';
+    private $toastMessages = 'project/conducting.data-extraction.buttons';
+
     public $projectId;
     public $duplicates = []; // Armazena os papers duplicados organizados por título
     public $uniquePapers = [];
     public $exactDuplicateCount = 0;
 
     public $totalDuplicates = 0;
+
+    protected function messages()
+    {
+        return [
+            'no-papers' => __($this->translationPath . '.no-papers'),
+        ];
+    }
 
     private function translate(string $message, string $key = 'duplicates')
     {
@@ -295,6 +306,16 @@ class Buttons extends Component
     public function exportCsv()
     {
         $papers = $this->getPapersExport($this->projectId);
+        
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $csvData = $this->formatCsv($papers);
         return response()->streamDownload(function() use ($csvData) {
             echo $csvData;
@@ -304,6 +325,16 @@ class Buttons extends Component
     public function exportXml()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+
         $xmlData = $this->formatXml($papers);
         return response()->streamDownload(function() use ($xmlData) {
             echo $xmlData;
@@ -313,6 +344,16 @@ class Buttons extends Component
     public function exportPdf()
     {
         $papers = $this->getPapersExport($this->projectId);
+
+        // Verifica se existem papers para exportar
+        if ($papers->isEmpty()) {
+            $this->toast(
+                message: $this->toastMessages . '.no-papers',
+                type: 'error'
+            );
+            return;
+        }
+        
         $pdfData = $this->formatPdf($papers);
         return response()->streamDownload(function() use ($pdfData) {
             echo $pdfData;

--- a/app/Livewire/Planning/DataExtraction/Option.php
+++ b/app/Livewire/Planning/DataExtraction/Option.php
@@ -85,8 +85,7 @@ class Option extends Component
     {
         $this->optionId = null;
         $this->description = null;
-        $this->questionId['value'] = $this->currentProject
-            ->dataExtractionQuestions->first()->id_de ?? null;
+        $this->questionId = [];
         $this->form['isEditing'] = false;
     }
 

--- a/lang/en/project/conducting.php
+++ b/lang/en/project/conducting.php
@@ -205,6 +205,7 @@ return [
             'select-database' => 'Show all Databases',
             'select-status' => 'Show all Statuses...',
             'search-papers' => 'Search papers...',
+            'no-papers' => 'No studies available for export.',
         ],
         'modal' => [
             'author' => 'Author',
@@ -416,6 +417,7 @@ return [
             'select-database' => 'Show all Databases',
             'select-status' => 'Show all Statuses...',
             'search-papers' => 'Search papers...',
+            'no-papers' => 'No studies available for export.',
         ],
         'modal' => [
             'author' => 'Author',

--- a/lang/pt_BR/project/conducting.php
+++ b/lang/pt_BR/project/conducting.php
@@ -199,6 +199,7 @@ return [
             'select-status' => 'Mostrar todos os Status...',
             'select-type' => 'Mostrar todos os Tipos...',
             'search-papers' => 'Pesquisar artigos...',
+            'no-papers' => 'Não há estudos disponíveis para exportar',
         ],
         'modal' => [
             'author' => 'Autor',
@@ -383,6 +384,7 @@ return [
             'select-database' => 'Mostrar todos as Bases',
             'select-status' => 'Mostrar todos Status...',
             'search-papers' => 'Buscar estudos...',
+            'no-papers' => 'Não há estudos disponíveis para exportar',
         ],
         'modal' => [
             'author' => 'Autor',
@@ -511,6 +513,7 @@ return [
             'select-database' => 'Mostrar todas as Bases de Dados',
             'select-status' => 'Mostrar todos os Status...',
             'search-papers' => 'Pesquisar artigos...',
+            'no-papers' => 'Não há estudos disponíveis para exportar',
         ],
         'modal' => [
             'author' => 'Autor',


### PR DESCRIPTION
In these commits, I fixed the 500 server error that occurred when clicking the Export buttons for CSV, XML, or PDF (bug01). Now, before exporting, the method checks whether the papers array is empty: if it is, a toast with a specific error message is shown; if not, the export proceeds normally. Bug03 was caused by the form fields not being properly reseted. I have fixed this issue as well.