### PR TITLE
Problemas de visibilidade ao alternar cores (barra branca e modo escuro)

### DIFF
--- a/public/assets/js/argon-dashboard.js
+++ b/public/assets/js/argon-dashboard.js
@@ -2406,33 +2406,33 @@ window.sidebarType = function (a) {
 
   sidebar.classList.add(color); // Remove text-white/text-dark classes
 
-  if (color == 'bg-white') {
-    var textWhites = document.querySelectorAll('.sidenav .text-white');
+  if (color === 'bg-white') {
+    var elements = document.querySelectorAll('.sidenav .text-white, .sidenav .text-dark, .sidenav .nav-link, .sidenav .nav-link i, .sidenav .nav-link span, .sidenav h6, .sidenav strong, .sidenav .navbar-brand, .sidenav .navbar-brand *');
 
-    for (var _i = 0; _i < textWhites.length; _i++) {
-      textWhites[_i].classList.remove('text-white');
+    for (var i = 0; i < elements.length; i++) {
+      elements[i].classList.remove('text-white');
+      elements[i].classList.remove('text-dark');
 
-      textWhites[_i].classList.add('text-dark');
+      if (bodyDark) {
+        elements[i].classList.add('text-dark');
+        elements[i].style.setProperty('color', '#111827', 'important');
+      } else {
+        elements[i].classList.add('text-dark');
+        elements[i].style.removeProperty('color');
+      }
     }
   } else {
-    var textDarks = document.querySelectorAll('.sidenav .text-dark');
+    var elements = document.querySelectorAll('.sidenav .text-dark, .sidenav .text-white, .sidenav .nav-link, .sidenav .nav-link i, .sidenav .nav-link span, .sidenav h6, .sidenav strong, .sidenav .navbar-brand, .sidenav .navbar-brand *');
 
-    for (var _i2 = 0; _i2 < textDarks.length; _i2++) {
-      textDarks[_i2].classList.add('text-white');
-
-      textDarks[_i2].classList.remove('text-dark');
+    for (var i = 0; i < elements.length; i++) {
+      elements[i].classList.remove('text-dark');
+      elements[i].classList.remove('text-white');
+      elements[i].classList.add('text-white');
+      elements[i].style.removeProperty('color');
     }
   }
-
-  if (color == 'bg-default' && bodyDark) {
-    var textDarks = document.querySelectorAll('.navbar-brand .text-dark');
-
-    for (var _i3 = 0; _i3 < textDarks.length; _i3++) {
-      textDarks[_i3].classList.add('text-white');
-
-      textDarks[_i3].classList.remove('text-dark');
-    }
-  } // Remove logo-white/logo-dark
+  
+  // Remove logo-white/logo-dark
 
 
   if (color == 'bg-white' && bodyWhite) {
@@ -2906,9 +2906,9 @@ window.darkMode = function (el) {
       btn_text_dark[i].classList.add('text-white');
     }
 
-    for (var i = 0; i < sidebarWhite.length; i++) {
+    /*for (var i = 0; i < sidebarWhite.length; i++) {
       sidebarWhite[i].classList.remove('bg-white');
-    }
+    }*/
 
     for (var i = 0; i < svg.length; i++) {
       if (svg[i].hasAttribute('fill')) {
@@ -2923,7 +2923,7 @@ window.darkMode = function (el) {
     el.setAttribute("checked", "true");
   } else {
     body.classList.remove('dark-version');
-    sidebar.classList.add('bg-white');
+    //sidebar.classList.add('bg-white');
 
     if (navbarBrandImg.includes('logo-ct.png')) {
       var navbarBrandImgNew = navbarBrandImg.replace("logo-ct", "logo-ct-dark");
@@ -3015,6 +3015,23 @@ window.darkMode = function (el) {
 
     for (var i = 0; i < card_border_dark.length; i++) {
       card_border_dark[i].classList.remove('border-dark');
+    }
+    
+    var sidebarElements = document.querySelectorAll(
+      '.sidenav .nav-link, .sidenav .nav-link i, .sidenav .nav-link span, .sidenav h6, .sidenav strong, .sidenav .navbar-brand, .sidenav .navbar-brand *'
+    );
+
+    for (var i = 0; i < sidebarElements.length; i++) {
+      const el = sidebarElements[i];
+      el.classList.remove('text-white', 'text-dark', 'text-blue-600');
+      el.style.removeProperty('color');
+
+      if (sidebar.classList.contains('bg-white')) {
+        el.classList.add('text-dark');
+        el.style.setProperty('color', '#111827', 'important');
+      } else {
+        el.classList.add('text-white');
+      }
     }
 
     el.removeAttribute("checked");

--- a/public/assets/js/argon-dashboard.js
+++ b/public/assets/js/argon-dashboard.js
@@ -2826,6 +2826,18 @@ window.darkMode = function (el) {
   if (!el.getAttribute("checked")) {
     body.classList.add('dark-version');
 
+    if (sidebar.classList.contains('bg-white')) {
+      var sidebarElements = document.querySelectorAll(
+        '.sidenav .nav-link, .sidenav .nav-link i, .sidenav .nav-link span, .sidenav h6, .sidenav strong, .sidenav .navbar-brand, .sidenav .navbar-brand *'
+      );
+      for (var i = 0; i < sidebarElements.length; i++) {
+        const el = sidebarElements[i];
+        el.classList.remove('text-white', 'text-blue-600');
+        el.classList.add('text-dark');
+        el.style.setProperty('color', '#111827', 'important');
+      }
+    }
+
     if (navbarBrandImg.includes('logo-ct-dark.png')) {
       var navbarBrandImgNew = navbarBrandImg.replace("logo-ct-dark", "logo-ct");
       navbarBrand.src = navbarBrandImgNew;
@@ -3034,6 +3046,13 @@ window.darkMode = function (el) {
       }
     }
 
+    var theads = document.querySelectorAll('thead th');
+    for (var i = 0; i < theads.length; i++) {
+      theads[i].classList.remove('text-white');
+      theads[i].classList.remove('opacity-8');
+      theads[i].classList.add('text-secondary');
+    }
+    
     el.removeAttribute("checked");
   }
 };


### PR DESCRIPTION
Foi realizado ajuste na alteração das cores branco/escuro da barra lateral e do tema claro/escuro.
Considerando os seguintes fluxos:
barra escura -> tema escuro -> tema claro
barra escura -> tema escuro -> barra branca

originalmente, em ambos os casos a barra lateral ficava branca e sem aparecer as letras e ícones

além disso, agora essas funções funcionam de forma independente, então ao alterar o tema para escuro, somente o fundo é alterado e a barra permanece branca, caso não tenha sido alterada para o modo escuro.