### PR TITLE
fix(FileUpload.php, Question.php, SearchTerm.php e ValidBibFile.php)

### DIFF
--- a/app/Livewire/Conducting/FileUpload.php
+++ b/app/Livewire/Conducting/FileUpload.php
@@ -88,7 +88,7 @@ class FileUpload extends Component
             // Preparar o nome do arquivo para salvar
             $originalName = pathinfo($this->file->getClientOriginalName(), PATHINFO_FILENAME);
             $cleanName = str_replace(' ', '_', $originalName);
-            $extension = $this->file->getClientOriginalExtension();
+            $extension = strtolower($this->file->getClientOriginalExtension());
             $name = $cleanName . '.' . $extension;
             FacadesLog::info('Preparando o nome do arquivo para salvar.', ['file_name' => $name]);
 
@@ -220,7 +220,7 @@ class FileUpload extends Component
     /**
      * @throws ParserException
      */
-     private function extractBibTexReferences($filePath)
+    private function extractBibTexReferences($filePath)
     {
         $contents = file_get_contents($filePath);
         $parser = new Parser();

--- a/app/Livewire/Planning/DataExtraction/Question.php
+++ b/app/Livewire/Planning/DataExtraction/Question.php
@@ -106,19 +106,19 @@ class Question extends Component
     {
         $this->validate();
 
-        // Verifica se o 'id' da questão já existe no projeto atual (em modo de criação)
-        if (!$this->form['isEditing']) {
-            $existingQuestion = QuestionModel::where('id', $this->questionId)
-                ->where('id_project', $this->currentProject->id_project)
-                ->first();
+        $existingQuestion = QuestionModel::where('id', $this->questionId)
+            ->where('id_project', $this->currentProject->id_project)
+            ->when($this->form['isEditing'], function ($query) {
+                return $query->where('id', '!=', $this->currentQuestion->id);
+            })
+            ->first();
 
-            if ($existingQuestion) {
-                $this->toast(
-                    message: 'Já existe uma questão com este ID neste projeto.',
-                    type: 'error'
-                );
-                return;
-            }
+        if ($existingQuestion) {
+            $this->toast(
+                message: 'Já existe uma questão com este ID neste projeto.',
+                type: 'error'
+            );
+            return;
         }
 
         try {

--- a/app/Livewire/Planning/SearchString/SearchTerm.php
+++ b/app/Livewire/Planning/SearchString/SearchTerm.php
@@ -123,7 +123,7 @@ class SearchTerm extends Component
         try {
             $value = $this->form['isEditing'] ? 'Updated the term' : 'Added a term';
             $toastMessage = __($this->toastMessages . ($this->form['isEditing']
-                ? '.updated' : '.added'));
+                    ? '.updated' : '.added'));
 
             $updatedOrCreated = SearchTermModel::updateOrCreate($updateIf, [
                 'id_project' => $this->currentProject->id_project,
@@ -198,8 +198,16 @@ class SearchTerm extends Component
 
     public function addSynonyms()
     {
-        if (!$this->termId['value'] || !$this->synonym) {
+        // validacao do termo
+        if (!$this->termId['value']) {
             $this->addError('termId', 'The term id is required');
+            return;
+        }
+
+        //validacao do sinonimo
+        if (empty(trim($this->synonym))) {
+            $this->addError('synonym', 'The synonym is required');
+            return;
         }
 
         $updateIf = [
@@ -209,7 +217,7 @@ class SearchTerm extends Component
         try {
             $value = $this->form['isEditing'] ? 'Updated the synonym' : 'Added a synonym';
             $toastMessage = __($this->toastMessages . ($this->form['isEditing']
-                ? '.updated' : '.added'));
+                    ? '.updated' : '.added'));
 
             $created = SynonymModel::updateOrCreate($updateIf, [
                 'id_term' => $this->termId['value'],
@@ -236,7 +244,6 @@ class SearchTerm extends Component
             $this->resetFields();
         }
     }
-
     /**
      * Fill the form fields with the given data.
      */

--- a/app/Rules/ValidBibFile.php
+++ b/app/Rules/ValidBibFile.php
@@ -9,7 +9,7 @@ class ValidBibFile implements Rule
     public function passes($attribute, $value)
     {
         $extension = $value->getClientOriginalExtension();
-        return in_array($extension, ['bib', 'csv', 'txt']);
+        return in_array($extension, ['bib', 'csv', 'txt', 'CSV']);
     }
 
     public function message()


### PR DESCRIPTION
fix(FileUpload.php e ValidBibFile.php)
Problema ao importar arquivos com a extensão .CSV (letras maiúsculas): o sistema aceitava apenas em letras minúsculas. Isso foi resolvido adicionando CSV como um termo válido no arquivo ValidBibFile.php, além de uma segunda medida utilizando strtolower na variável que recebe o tipo de extensão do arquivo

fix(Question.php)
Ao editar uma pergunta de extração de dados, era possível atualizar seu id para um já existente, criando dois registros de questões com o mesmo id. O código foi atualizado ajustando a verificação da questão, de modo que, ao criar ou editar o campo, é feita uma busca para verificar se o id já existe

fix(SearchTerm.php)
Havia um problema na adição de sinônimos vazios: ao selecionar um termo, na primeira tentativa de adicionar um sinônimo vazio, ele não era adicionado e uma mensagem de erro era exibida. No entanto, na segunda tentativa, o sistema permitia a criação de um sinônimo vazio. Isso foi corrigido adicionando uma validação adequada que verifica se o campo está vazio ou contém apenas espaços, na classe responsável