### PR TITLE
fix(bug 58): Comportamento de clique em elementos sem funcionalidade

### DIFF
--- a/resources/views/livewire/planning/databases/database-manager.blade.php
+++ b/resources/views/livewire/planning/databases/database-manager.blade.php
@@ -1,6 +1,6 @@
 <div class="card d-inline-flex mt-5 mb-3 w-100">
     <div class="card-body">
-        <a href="javascript:" class="card-title h5 d-block text-darker">
+        <a href="#" onclick="event.preventDefault();" class="card-title h5 d-block text-darker" style="cursor: default; transition: color 0.2s;">
             {{ __("project/planning.databases.database-manager.table.title") }}
         </a>
     </div>

--- a/resources/views/pages/about.blade.php
+++ b/resources/views/pages/about.blade.php
@@ -24,16 +24,20 @@
                 <div class="card d-inline-flex p-3 mt-5">
                     <div class="card-body pt-2">
                         <a
-                            href="javascript:;"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h4 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             Thoth 2.0
                         </a>
 
                         <div class="card-body pt-2">
                             <a
-                                href="javascript:"
+                                href="#"
+                                onclick="event.preventDefault();"
                                 class="card-title h5 d-block text-darker"
+                                style="cursor: default; transition: color 0.2s;"
                             >
                                 {{ __("pages/about.new_features") }}
                             </a>
@@ -58,8 +62,10 @@
                     </div>
                     <div class="card-body pt-2">
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h5 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.development") }}
                         </a>
@@ -67,8 +73,10 @@
                     </div>
                     <div class="card-body pt-2">
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h5 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.open_source_project") }}
                         </a>
@@ -79,8 +87,10 @@
                             {{ __("pages/about.mit_license") }}
                         </a>
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.technologies_used") }}
                         </a>
@@ -102,8 +112,10 @@
 
                     <div class="card-body pt-2">
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h5 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.about_the_tool") }}
                         </a>
@@ -118,8 +130,10 @@
                         />
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.cross_platform") }}
                         </a>
@@ -128,8 +142,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.automate_process") }}
                         </a>
@@ -138,8 +154,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.search_string") }}
                         </a>
@@ -148,8 +166,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.management_selection") }}
                         </a>
@@ -158,8 +178,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.management_quality") }}
                         </a>
@@ -168,8 +190,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.data_generation") }}
                         </a>
@@ -178,8 +202,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.graphs_tables_generation") }}
                         </a>
@@ -188,8 +214,10 @@
                         </p>
 
                         <a
-                            href="javascript:"
+                            href="#"
+                            onclick="event.preventDefault();"
                             class="card-title h6 d-block text-darker"
+                            style="cursor: default; transition: color 0.2s;"
                         >
                             {{ __("pages/about.report_generation") }}
                         </a>
@@ -205,8 +233,10 @@
                         <ul>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.multiple_member_management") }}
                                 </a>
@@ -216,8 +246,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.manage_projects") }}
                                 </a>
@@ -227,8 +259,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.activity_view") }}
                                 </a>
@@ -238,8 +272,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.progress_display") }}
                                 </a>
@@ -249,8 +285,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.protocol_management") }}
                                 </a>
@@ -260,8 +298,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.study_import") }}
                                 </a>
@@ -271,8 +311,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.selection_of_studies") }}
                                 </a>
@@ -282,8 +324,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.checking_duplicate_studies") }}
                                 </a>
@@ -293,8 +337,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.selection_ranking_information") }}
                                 </a>
@@ -304,8 +350,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.study_information_visualization") }}
                                 </a>
@@ -315,8 +363,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.status_for_each_member") }}
                                 </a>
@@ -326,8 +376,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.conflicts_in_selection") }}
                                 </a>
@@ -337,8 +389,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.resolution_of_conflicts_in_selection") }}
                                 </a>
@@ -348,8 +402,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.quality_assessment_of_studies") }}
                                 </a>
@@ -359,8 +415,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.quality_conflicts") }}
                                 </a>
@@ -370,8 +428,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.data_extraction") }}
                                 </a>
@@ -381,8 +441,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.report") }}
                                 </a>
@@ -392,8 +454,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.export_to_latex") }}
                                 </a>
@@ -403,8 +467,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.export_to_bibtex") }}
                                 </a>
@@ -414,8 +480,10 @@
                             </li>
                             <li>
                                 <a
-                                    href="javascript:"
+                                    href="#"
+                                    onclick="event.preventDefault();"
                                     class="card-title h5 d-block text-darker"
+                                    style="cursor: default; transition: color 0.2s;"
                                 >
                                     {{ __("pages/about.improvement_of_search_strings") }}
                                 </a>

--- a/resources/views/pages/help.blade.php
+++ b/resources/views/pages/help.blade.php
@@ -20,11 +20,11 @@
             <div class="mt-lg-n12 mt-md-n13 mt-n12 justify-content-center">
                 <div class="card d-inline-flex p-3 mt-8 mb-5">
                     <div class="card-body pt-2">
-                        <a href="javascript:;" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                             Thoth 2.0
                         </a>
                         <div class="card-body pt-2">
-                            <a href="javascript:" class="card-title h4 d-block text-darker">
+                        <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                                 {{ __('pages/help.common_questions') }}
                             </a>
                         </div>
@@ -38,7 +38,7 @@
                                         </a>
                                     </button>
                                 </h2>
-                                <div id="collapseOne" class="accordion-collapse collapse show"
+                                <div id="collapseOne" class="accordion-collapse collapse"
                                     data-bs-parent="#accordionExample">
                                     <div class="accordion-body">
                                     {{ __('pages/help.answer1') }}

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -30,7 +30,7 @@
         <div class="mt-lg-n12 mt-md-n13 mt-n12 justify-content-center">
             <div class="card d-inline-flex mt-5">
                 <div class="card-body">
-                    <a href="javascript:" class="card-title h5 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h5 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/home.thoth") }}
                     </a>
                     <p class="card-description mb-0">
@@ -49,7 +49,7 @@
                 as $key => $icon)
                 <div class="card rounded-3 p-3 d-flex flex-column h-100">
                     <div class="card-body pt-2 d-flex flex-column">
-                        <a href="javascript:" class="card-title h5 d-flex align-items-center gap-2 text-darker">
+                        <a href="#" onclick="event.preventDefault();" class="card-title h5 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                             <i class="{{ $icon }}"></i>
                             {{ __("pages/home." . $key) }}
                         </a>
@@ -68,7 +68,7 @@
         <div class="col-lg-3 col-md-6 mb-4">
             <div class="card text-center h-100">
                 <div class="card-body d-flex flex-column">
-                    <a href="javascript:">
+                    <a href="#" onclick="event.preventDefault();" style="cursor: default; transition: color 0.2s;">
                         <i class="fas fa-project-diagram fa-2x mb-2"></i>
                         <h2 class="h2 card-title mt-auto"><span id="project-count">0</span></h2>
                         <h6 class="h6 card-text">{{ __("pages/home.total_projects") }} </h6>
@@ -80,7 +80,7 @@
         <div class="col-lg-3 col-md-6 mb-4">
             <div class="card text-center h-100">
                 <div class="card-body d-flex flex-column">
-                    <a href="javascript:">
+                    <a href="#" onclick="event.preventDefault();" style="cursor: default; transition: color 0.2s;">
                         <i class="fas fa-users fa-2x mb-2"></i>
                         <h2 class="card-title mt-auto hover-text"><span id="user-count">0</span></h2>
                         <h6 class="card-text">{{ __("pages/home.total_users") }}</h6>
@@ -92,7 +92,7 @@
         <div class="col-lg-3 col-md-6 mb-4">
             <div class="card text-center h-100">
                 <div class="card-body d-flex flex-column">
-                    <a href="javascript:">
+                    <a href="#" onclick="event.preventDefault();" style="cursor: default; transition: color 0.2s;">
                         <i class="fas fa-check-circle fa-2x mb-2"></i>
                         <h2 class="card-title mt-auto"><span id="total-finished-projects-count">0</span></h2>
                         <h6 class="card-text">{{ __("pages/home.completed_projects") }}</h6>
@@ -103,7 +103,7 @@
         <div class="col-lg-3 col-md-6 mb-4">
             <div class="card text-center h-100">
                 <div class="card-body d-flex flex-column">
-                    <a href="javascript:">
+                    <a href="#" onclick="event.preventDefault();" style="cursor: default; transition: color 0.2s;">
                         <i class="fas fa-spinner fa-2x mb-2"></i>
                         <h2 class="card-title mt-auto"><span id="total-ongoing-projects-count">0</span></h2>
                         <h6 class="card-text">{{ __("pages/home.ongoing_projects") }}</h6>

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -20,7 +20,7 @@
         <div class="mt-lg-n12 mt-md-n13 mt-n12 justify-content-center">
             <div class="card d-inline-flex p-3 mt-5">
                 <div class="card-body pt-2">
-                    <a href="javascript:;" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.what") }}
                     </a>
                     <p>
@@ -32,19 +32,19 @@
                     <p>{{ __("pages/terms.author") }}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.authoral") }}
                     </a>
                     <p>{{ __("pages/terms.authoral_text") }}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.who") }}
                     </a>
                     <p>{{ __("pages/terms.who_text") }}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.commitment") }}
                     </a>
                     <p>{{ __("pages/terms.commitment_text") }}</p>
@@ -93,32 +93,32 @@
                     </ul>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.responsability") }}
                     </a>
                     <p>{{ __("pages/terms.responsability_text") }}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.privacy") }}
                     </a>
                     <p>{!!  __("pages/terms.privacy_text") !!}</p>
                 </div>
 
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.delete_data") }}
                     </a>
                     <p>{!!  __("pages/terms.delete_data_text")  !!}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.exclusion_data") }}
                     </a>
                     <p>{!!  __("pages/terms.exclusion_data_text")  !!}</p>
                 </div>
                 <div class="card-body pt-2">
-                    <a href="javascript:" class="card-title h4 d-block text-darker">
+                    <a href="#" onclick="event.preventDefault();" class="card-title h4 d-block text-darker" style="cursor: default; transition: color 0.2s;">
                         {{ __("pages/terms.security_data") }}
                     </a>
                     <p>{!!  __("pages/terms.security_data_text")  !!}</p>


### PR DESCRIPTION
Ao acessar algumas páginas principais da plataforma (Início, Sobre, Ajuda e Termos e Política de Privacidade), observou-se que alguns elementos da interface apareciam como clicáveis, apesar de não possuírem nenhum tipo de função, como na evidência a seguir:
https://jam.dev/c/defa0930-0f2a-4724-be0c-01701eb901e0

Pode-se afirmar que utilizar elementos que não possuem uma navegação pode confundir o usuário e dificultar a compreensão da plataforma, uma vez que o usuário pode acreditar que isso é um bug e que não está conseguindo acessar informações adicionais sobre um determinado tópico.

Com o fito de evitar interpretações equivocadas, modifiquei os elementos para que mudem de cor ao passar o cursor e removi a funcionalidade de clique.