### PR TITLE
fix: snowballing tab on reporting page

### DIFF
--- a/resources/views/project/reporting/index.blade.php
+++ b/resources/views/project/reporting/index.blade.php
@@ -4,51 +4,59 @@
     @include('layouts.navbars.auth.topnav', ['title' => __('nav/topnav.reporting')])
 
     <div class="row mt-4 mx-4">
-
         @include('project.components.project-header', ['project' => $project, 'activePage' => 'reporting'])
+        @php
+            $tabs = [
+                [
+                    'id' => 'overview-tab',
+                    'label' => __('project/reporting.header.overview'),
+                    'href' => '#overview'
+                ],
+                [
+                    'id' => 'import-studies-tab',
+                    'label' => __('project/reporting.header.import_studies'),
+                    'href' => '#import-studies',
+                ],
+                [
+                    'id' => 'study-selection-tab',
+                    'label' => __('project/reporting.header.study_selection'),
+                    'href' => '#study-selection',
+                ],
+                [
+                    'id' => 'quality-assessment-tab',
+                    'label' => __('project/reporting.header.quality_assessment'),
+                    'href' => '#quality-assessment',
+                ],
+                [
+                    'id' => 'data-extraction-tab',
+                    'label' => __('project/reporting.header.data_extraction'),
+                    'href' => '#data-extraction',
+                ],
+                [
+                    'id' => 'reliability-tab',
+                    'label' => __('project/reporting.header.reliability'),
+                    'href' => '#reliability',
+                ],
+            ];
+
+            if (
+                $project->feature_review === 'Systematic review and Snowballing' ||
+                $project->feature_review === 'Snowballing'
+            ) {
+                $tabs[] = [
+                    'id' => 'snowballing-tab',
+                    'label' => __('project/reporting.header.snowballing'),
+                    'href' => '#snowballing',
+                ];
+            }
+        @endphp
 
         <div class="container-fluid py-4">
             <div class="row">
                 <div class="col-12">
                     @include('project.components.project-tabs', [
                         'header' => __('project/reporting.reporting'),
-                        'tabs' => [
-                            [
-                                'id' => 'overview-tab',
-                                'label' => __('project/reporting.header.overview'),
-                                'href' => '#overview'
-                            ],
-                            [
-                                'id' => 'import-studies-tab',
-                                'label' => __('project/reporting.header.import_studies'),
-                                'href' => '#import-studies',
-                            ],
-                            [
-                                'id' => 'study-selection-tab',
-                                'label' => __('project/reporting.header.study_selection'),
-                                'href' => '#study-selection',
-                            ],
-                            [
-                                'id' => 'quality-assessment-tab',
-                                'label' => __('project/reporting.header.quality_assessment'),
-                                'href' => '#quality-assessment',
-                            ],
-                            [
-                                'id' => 'data-extraction-tab',
-                                'label' => __('project/reporting.header.data_extraction'),
-                                'href' => '#data-extraction',
-                            ],
-                            [
-                                'id' => 'reliability-tab',
-                                'label' => __('project/reporting.header.reliability'),
-                                'href' => '#reliability',
-                            ],
-                             [
-                                'id' => 'snowballing-tab',
-                                'label' => __('project/reporting.header.snowballing'),
-                                'href' => '#snowballing',
-                            ],
-                        ],
+                        'tabs' => $tabs,
                         'activeTab' => 'overview-tab',
                     ])
                     <div class="tab-content mt-4">
@@ -73,14 +81,17 @@
                             @livewire('reporting.data-extraction')
                         </div>
                         <div class="tab-pane fade" id="reliability">
-                            <!-- Content for Snowballing tab -->
+                            <!-- Content for Reliability tab -->
                            @livewire('reporting.reliability')
                         </div>
-                        @if (strpos($project->feature_review, 'Snowballing') !== false || strpos($project->feature_review, 'Systematic Review and Snowballing') !== false)
-                        <div class="tab-pane fade" id="snowballing">
-                            <!-- Content for Snowballing tab -->
-                            @livewire('reporting.snowballing')
-                        </div>
+                        @if (
+                            $project->feature_review === 'Systematic review and Snowballing' ||
+                            $project->feature_review === 'Snowballing'
+                        )
+                            <div class="tab-pane fade" id="snowballing">
+                                <!-- Content for Snowballing tab -->
+                                @livewire('reporting.snowballing')
+                            </div>
                         @endif
                     </div>
                 </div>


### PR DESCRIPTION
A aba de Snowballing na página de "Relatórios" aparecia sempre, independente do tipo de projeto selecionado.

![image](https://github.com/user-attachments/assets/b6bf6267-3d7e-4e9a-aef0-7d8ce880693a)

Com o ajuste, agora só irá aparecer nos projetos "Revisão sistemática e Snowballing" e "Snowballing", ficando escondida em projetos que são apenas "Revisão sistemática".