### PR TITLE
fix(12): Correção de idioma em elementos disponíveis apenas em português

### DIFF
--- a/lang/en/nav/nav.php
+++ b/lang/en/nav/nav.php
@@ -20,6 +20,7 @@ return [
     'language' => 'Language',
     'profile' => 'Profile',
     'logout' => 'Logout',
+    'settings' => 'Settings',
     'projects' => 'Projects',
     'my_projects' => 'My Projects',
     'pages' => 'Pages',

--- a/lang/en/pages/project.php
+++ b/lang/en/pages/project.php
@@ -13,5 +13,5 @@ return [
     'enter_the_title' => 'Enter the title',
     'enter_the_description' => 'Enter the description',
     'enter_the_objectives' => 'Enter the objectives',
-
+    'project_chat' => 'Project Chat'
 ];

--- a/lang/pt_BR/nav/nav.php
+++ b/lang/pt_BR/nav/nav.php
@@ -19,6 +19,7 @@ return [
     'language' => 'Idioma',
     'profile' => 'Perfil',
     'logout' => 'Deslogar',
+    'settings' => 'Configurações',
     'projects' => 'Projetos',
     'my_projects' => 'Meus Projetos',
     'pages' => 'Páginas',

--- a/lang/pt_BR/pages/project.php
+++ b/lang/pt_BR/pages/project.php
@@ -13,4 +13,5 @@ return[
     'enter_the_title' => 'Digite o título',
     'enter_the_description' => 'Digite a descrição',
     'enter_the_objectives' => 'Digite os objetivos',
+    'project_chat' => 'Bate-papo do Projeto'
 ];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -254,7 +254,7 @@ class="g-sidenav-show {{ in_array( request()->route()->getName(),["login", "rese
     <!-- CHAT flutuante -->
     <div id="chat-container" style="position:fixed; bottom:0; right:15px; width:300px; z-index:9999;">
         <div id="chat-header" style="background:#007bff;color:#fff;padding:8px;cursor:pointer;">
-            Chat do Projeto
+            <span>{{ __('pages/project.project_chat') }}</span>
             <span id="chat-notif" style="float:right;background:red;padding:2px 5px;border-radius:10px;display:none;">!</span>
         </div>
         <div id="chat-body" style="border:1px solid #ccc;background:#fff;height:250px;overflow:auto;display:none;padding:10px;">

--- a/resources/views/layouts/navbars/auth/topnav.blade.php
+++ b/resources/views/layouts/navbars/auth/topnav.blade.php
@@ -60,6 +60,7 @@
                 <li class="nav-item px-3 d-flex align-items-center">
                     <a href="javascript:;" class="nav-link p-0">
                         <i class="fa fa-cog fixed-plugin-button-nav cursor-pointer"></i>
+                        <span>{{ __('nav/nav.settings') }}</span>
                     </a>
                 </li>
 

--- a/resources/views/layouts/navbars/guest/navbar.blade.php
+++ b/resources/views/layouts/navbars/guest/navbar.blade.php
@@ -25,7 +25,7 @@
                                     <span class="input-group-text text-body">
                                         <i class="fas fa-search" aria-hidden="true"></i>
                                     </span>
-                                    <input type="text" name="searchProject" class="form-control" placeholder="Pesquisar no Thoth...">
+                                    <input type="text" name="searchProject" class="form-control" placeholder="{{ __('nav/nav.search_in_thoth') }}">
                                 </div>
                             </form>
                         </div>
@@ -108,7 +108,7 @@
                             <li class="nav-item me-1 d-flex align-items-center">
                                 <a href="javascript:;" class="nav-link text-dark p-0 d-flex align-items-center">
                                     <i class="fa fa-cog opacity-6 me-1 fixed-plugin-button-nav cursor-pointer"></i>
-                                    <span class="d-sm-inline d-none">Configurações</span>
+                                    <span>{{ __('nav/nav.settings') }}</span>
                                 </a>
                             </li>
                         </ul>


### PR DESCRIPTION
Identificou-se que alguns elementos do site não estavam sendo traduzidos para o inglês, como o botão de configurações e o chat do projeto.
Assim sendo, os arquivos responsáveis pela mudança de idioma foram modificados, abrangendo todos os elementos da plataforma e disponibilizando a mudança de idioma para português e inglês.