### PR TITLE
fix(12): Correção de navbar com campo de pesquisa sem funcionalidade

### DIFF
--- a/lang/en/nav/nav.php
+++ b/lang/en/nav/nav.php
@@ -24,7 +24,7 @@ return [
     'projects' => 'Projects',
     'my_projects' => 'My Projects',
     'pages' => 'Pages',
-    'search_in_thoth' => 'Search in Thoth...',
+    'search_in_thoth' => 'Search Project in Thoth...',
     'terms_and_conditions' => 'Terms and <br/>Privacy Policy',
     'documentation' => 'Documentation',
 ];

--- a/lang/en/nav/topnav.php
+++ b/lang/en/nav/topnav.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'search_in_thoth_placeholder' => 'Search in Thoth...',
+    'search_in_thoth_placeholder' => 'Search Project in Thoth...',
 
     'pages' => 'Pages',
     'project' => 'Project',

--- a/lang/pt_BR/nav/nav.php
+++ b/lang/pt_BR/nav/nav.php
@@ -23,7 +23,7 @@ return [
     'projects' => 'Projetos',
     'my_projects' => 'Meus Projetos',
     'pages' => 'Páginas',
-    'search_in_thoth' => 'Pesquisar no Thoth...',
+    'search_in_thoth' => 'Pesquisar Projeto na Thoth...',
     'terms_and_conditions' => 'Termos e Politica <br/> de Privacidade',
     'documentation'=>'Manuais/Documentação'
 ];

--- a/lang/pt_BR/nav/topnav.php
+++ b/lang/pt_BR/nav/topnav.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'search_in_thoth_placeholder' => 'Pesquisar na Thoth...',
+    'search_in_thoth_placeholder' => 'Pesquisar Projeto na Thoth...',
 
     'pages' => 'Páginas',
     'project' => 'Projeto',

--- a/resources/views/layouts/navbars/guest/navbar.blade.php
+++ b/resources/views/layouts/navbars/guest/navbar.blade.php
@@ -18,19 +18,8 @@
 
                     <!-- Itens do menu (colapsáveis) -->
                     <div class="collapse navbar-collapse" id="navigation">
-                        <!-- Barra de pesquisa -->
-                        <div class="d-flex align-items-center ms-auto me-3" style="max-width: 250px; width: 100%;">
-                            <form action="/search-project" method="get" class="w-100">
-                                <div class="input-group">
-                                    <span class="input-group-text text-body">
-                                        <i class="fas fa-search" aria-hidden="true"></i>
-                                    </span>
-                                    <input type="text" name="searchProject" class="form-control" placeholder="{{ __('nav/nav.search_in_thoth') }}">
-                                </div>
-                            </form>
-                        </div>
 
-                        <ul class="navbar-nav d-flex align-items-center">
+                        <ul class="navbar-nav d-flex align-items-center ms-auto">
                             <li class="nav-item me-1">
                                 <a class="nav-link d-flex align-items-center" aria-current="page" href="{{ route('home') }}">
                                     <i class="fa fa-chart-pie opacity-6 text-dark me-1"></i>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -1,115 +1,82 @@
 @extends('layouts.app', ['class' => 'g-sidenav-show bg-gray-100'])
 
 @section('content')
-	@include('layouts.navbars.auth.topnav', ['title' => __('project/create.create_project')])
-	<div class="card shadow-lg mx-4">
-		<div class="container-fluid py-4">
-			<p class="text-uppercase text-sm">{{ __('project/create.create_project') }}</p>
-			<form method="POST" action="{{ route('projects.store') }}">
-				@csrf
-				<div class="form-group">
-					<label for="titleInput">{{ __('project/create.title') }}</label>
-					<input name="title" type="text" class="form-control @error('title') is-invalid @enderror"
-						id="titleInput" placeholder="{{ __('project/create.enter_title') }}" value="{{ old('title') }}">
-					@error('title')
-						<span class="invalid-feedback" role="alert">
-							{{ $message }}
-						</span>
-					@enderror
-				</div>
-				<!-- alterar o formato das caixas de texto de textarea para quill -->
+    @include('layouts.navbars.auth.topnav', ['title' => __('project/create.create_project') ])
+    <div class="card shadow-lg mx-4">
+        <div class="container-fluid py-4">
+            <p class="text-uppercase text-sm">{{ __('project/create.create_project')}}</p>
+            <form method="POST" action="{{ route('projects.store') }}">
+                @csrf
+                <div class="form-group">
+                    <label for="titleInput">{{ __('project/create.title')}}</label>
+                    <input name="title" type="text" class="form-control @error('title') is-invalid @enderror"
+                        id="titleInput" placeholder="{{ __('project/create.enter_title')}}" value="{{ old('title') }}">
+                    @error('title')
+                        <span class="invalid-feedback" role="alert">
+                            {{ $message }}
+                        </span>
+                    @enderror
+                </div>
+                <div class="form-group">
+                    <label for="descriptionTextarea">{{ __('project/create.description')}}</label>
+                    <textarea name="description" class="form-control @error('description') is-invalid @enderror" id="descriptionTextarea"
+                        rows="3" placeholder="{{ __('project/create.enter_description')}}">{{ old('description') }}</textarea>
+                    @error('description')
+                        <span class="invalid-feedback" role="alert">
+                            {{ $message }}
+                        </span>
+                    @enderror
+                </div>
+                <div class="form-group">
+                    <label for="objectivesTextarea">{{ __('project/create.objectives')}}</label>
+                    <textarea name="objectives" class="form-control @error('objectives') is-invalid @enderror" id="objectivesTextarea"
+                        rows="3" placeholder="{{ __('project/create.enter_objectives')}}">{{ old('objectives') }}</textarea>
+                    @error('objectives')
+                        <span class="invalid-feedback" role="alert">
+                            {{ $message }}
+                        </span>
+                    @enderror
+                </div>
+                <div class="form-group">
+                    <label for="copy_planning">{{ __('project/create.copy_planning') }}</label>
+                    <select class="form-control" id="copy_planning" name="copy_planning">
+                        @if(count($projects) > 0)
+                            <option value="none">{{ __('project/create.none') }}</option>
+                            @foreach($projects as $project)
+                                <option value="{{ $project->id_project }}">{{ $project->title }}</option>
+                            @endforeach
+                        @else
+                            <option value="none">{{ __('project/create.noProjects') }}</option>
+                        @endif
+                    </select>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review1" value = "Systematic review">
+                    {{ old('feature_review') == 'Systematic review' ? 'checked' : '' }}</input>
+                    <label class="form-check-label" for="feature_review1" >
+                        Systematic review
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review2"  value = "Systematic review and Snowballing">
+                    {{ old('feature_review') == 'Systematic review and Snowballing' ? 'checked' : '' }}</input>
+                    <label class="form-check-label" for="feature_review2">
+                        Systematic review and Snowballing
+                    </label>
+                </div> 
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review3"  value= "Snowballing">
+                    {{ old('feature_review') == 'Snowballing' ? 'checked' : '' }}</input>
+                    <label class="form-check-label" for="feature_review3">
+                         Snowballing
+                    </label>
+                </div>    
+                <div class="d-flex align-items-center">
+                    <button type="submit" class="btn btn-primary btn-sm ms-auto">Create</button>
+                </div>
+            </form>
+            @include('layouts.footers.auth.footer')
+        </div>
+    </div>
 
-
-				<div class="form-group">
-					<label for="descriptionEditor">{{ __('project/create.description') }}</label>
-					<div id="descriptionEditor" class="form-control @error('description') is-invalid @enderror"
-						style="min-height: 150px;">
-						{!! old('description') !!}
-					</div>
-					<input type="hidden" name="description" id="descriptionInput">
-					@error('description')
-						<span class="invalid-feedback" role="alert">
-							{{ $message }}
-						</span>
-					@enderror
-				</div>
-
-				<div class="form-group">
-					<label for="objectivesEditor">{{ __('project/create.objectives') }}</label>
-					<div id="objectivesEditor" class="form-control @error('objectives') is-invalid @enderror"
-						style="min-height: 150px;">
-						{!! old('objectives') !!}
-					</div>
-					<input type="hidden" name="objectives" id="objectivesInput">
-					@error('objectives')
-						<span class="invalid-feedback" role="alert">
-							{{ $message }}
-						</span>
-					@enderror
-				</div>
-				<div class="form-group">
-					<label for="copy_planning">@lang('project/create.copy_planning')</label>
-					<select class="form-control" id="copy_planning" name="copy_planning">
-						@if(count($projects) > 0)
-							<option value="none">@lang('project/create.none') </option>
-							@foreach($projects as $project)
-								<option value="{{ $project->id_project }}">{{ $project->title }}</option>
-							@endforeach
-						@else
-							<option value="none">@lang('project/create.noProjects')</option>
-						@endif
-					</select>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review1"
-						value="Systematic review">
-					{{ old('feature_review') == 'Systematic review' ? 'checked' : '' }}</input>
-					<label class="form-check-label" for="feature_review1">
-              {{ __('project/create.systematic-review') }}
-					</label>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review2"
-						value="Systematic review and Snowballing">
-					{{ old('feature_review') == 'Systematic review and Snowballing' ? 'checked' : '' }}</input>
-					<label class="form-check-label" for="feature_review2">
-                    {{ __('project/create.systematic-review') }} and Snowballing
-					</label>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review3"
-						value="Snowballing">
-					{{ old('feature_review') == 'Snowballing' ? 'checked' : '' }}</input>
-					<label class="form-check-label" for="feature_review3">
-						@lang('project/create.snowballing')
-					</label>
-				</div>
-				<div class="d-flex align-items-center">
-					<button type="submit" class="btn btn-primary btn-sm ms-auto">{{ __('project/create.create') }}</button>
-				</div>
-			</form>
-			@include('layouts.footers.auth.footer')
-		</div>
-	</div>
-
-	<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        // Initialize Quill for the Description field
-        var descriptionEditor = new Quill('#descriptionEditor', {
-            theme: 'snow'
-        });
-        // Sync the content of the editor with the hidden field
-        descriptionEditor.on('text-change', function () {
-            document.querySelector('#descriptionInput').value = descriptionEditor.root.innerHTML;
-        });
-
-        // Initialize Quill for the Objectives field
-        var objectivesEditor = new Quill('#objectivesEditor', {
-            theme: 'snow'
-        });
-        objectivesEditor.on('text-change', function () {
-            document.querySelector('#objectivesInput').value = objectivesEditor.root.innerHTML;
-        });
-    });
-</script>
 @endsection

--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -1,106 +1,72 @@
 @extends('layouts.app', ['class' => 'g-sidenav-show bg-gray-100'])
 
 @section('content')
-	@include('layouts.navbars.auth.topnav', ['title' => __('nav/topnav.edit')])
-	<div class="card shadow-lg mx-4">
-		<div class="container-fluid py-4">
-			<p class="text-uppercase text-sm">{{ __('nav/topnav.edit')}}</p>
-			<form method="POST" action="{{ route('projects.update', $project->id_project) }}" id="editProjectForm">
-				@csrf
-				@method('PUT')
-				<div class="form-group">
-					<label for="titleInput"> {{ __('project/edit.title')}}</label>
-					<input name="title" value="{{ $project->title }}" type="text" class="form-control" id="titleInput"
-						placeholder="{{ __('project/edit.enter_title') }}">
-				</div>
-				<!-- Container quill da descição, passando dados em HTML mas não vai até DB-->
-				<div class="form-group">
-					<label for="descriptionEditor">{{ __('project/edit.description')}}</label>
-					<div id="descriptionEditor" class="form-control" style="height: 150px;">{!! $project->description !!}
-					</div>
-					<input type="hidden" name="description" id="descriptionInput">
-				</div>
-				<!-- Container quill do objectives | Quill funcional, passando dados em HTML mas não vai até DB-->
-				<div class="form-group">
-					<label for="objectivesEditor">{{ __('project/edit.objectives')}}</label>
-					<div id="objectivesEditor" class="form-control" style="height: 150px;">{!! $project->objectives !!}
-					</div>
-					<input type="hidden" name="objectives" id="objectivesInput">
-				</div>
-				<div class="form-group">
-					<label for="copy_planning">{{ __('project/edit.copy_planning') }}</label>
-					<select class="form-control" id="copy_planning" name="copy_planning">
-						@if(count($projects) > 1)
-							<option value="none">{{ __('project/edit.none') }}</option>
-							@foreach($projects as $project_option)
-								@if (!($project_option->id_project == $project->id_project))
-									<option value="{{ $project_option->id_project }}">{{ $project_option->title }}</option>
-								@endif
-							@endforeach
-						@else
-							@foreach($projects as $project_option)
-								<option value="none">{{ $project_option->title }}</option>
-							@endforeach
-						@endif
-					</select>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review1"
-						value="Systematic review">
-					{{ old('feature_review') == 'Systematic review'}}</input>
-					<label class="form-check-label" for="feature_review1">
-						Systematic review
-					</label>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review2"
-						value="Systematic review and Snowballing">
-					{{ old('feature_review') == 'Systematic review and Snowballing'}}</input>
-					<label class="form-check-label" for="feature_review2">
-						Systematic review and Snowballing
-					</label>
-				</div>
-				<div class="form-check">
-					<input class="form-check-input" type="radio" name="feature_review" id="feature_review3"
-						value="Snowballing">
-					{{ old('feature_review') == 'Snowballing'}}</input>
-					<label class="form-check-label" for="feature_review3">
-						Snowballing
-					</label>
-				</div>
-
-				<div class="d-flex align-items-center">
-					<button type="submit" class="btn btn-primary btn-sm ms-auto">{{ __('project/edit.edit')}}</button>
-				</div>
-			</form>
-			@include('layouts.footers.auth.footer')
-		</div>
-	</div>
+    @include('layouts.navbars.auth.topnav', ['title' =>  __('nav/topnav.edit')])
+    <div class="card shadow-lg mx-4">
+        <div class="container-fluid py-4">
+            <p class="text-uppercase text-sm">{{ __('nav/topnav.edit')}}</p>
+            <form method="POST" action="{{ route('projects.update', $project->id_project) }}">
+                @csrf
+                @method('PUT')
+                <div class="form-group">
+                    <label for="titleInput"> {{ __('project/edit.title')}}</label>
+                    <input name="title" value="{{ $project->title }}" type="text" class="form-control" id="titleInput"
+                        placeholder="{{ __('project/edit.enter_title') }}">
+                </div>
+                <div class="form-group">
+                    <label for="descriptionTextarea">{{ __('project/edit.description')}}</label>
+                    <textarea name="description" class="form-control" id="descriptionTextarea" rows="3"
+                        placeholder="{{ __('project/edit.enter_description') }}">{{ $project->description }}</textarea>
+                </div>
+                <div class="form-group">
+                    <label for="objectivesTextarea">{{ __('project/edit.objectives')}}</label>
+                    <textarea name="objectives" class="form-control" id="objectivesTextarea" rows="3"
+                        placeholder="{{ __('project/edit.enter_objectives') }}">{{ $project->objectives }}</textarea>
+                </div>
+                <div class="form-group">
+                    <label for="copy_planning">{{ __('project/edit.copy_planning') }}</label>
+                    <select class="form-control" id="copy_planning" name="copy_planning">
+                        @if(count($projects) > 1)
+                            <option value="none">{{ __('project/edit.none') }}</option>
+                            @foreach($projects as $project_option)
+                                @if (!($project_option->id_project == $project->id_project))
+                                    <option value="{{ $project_option->id_project }}">{{ $project_option->title }}</option>
+                                @endif
+                            @endforeach
+                        @else
+                            @foreach($projects as $project_option)
+                                <option value="none">{{ $project_option->title }}</option>
+                            @endforeach
+                        @endif
+                    </select>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review1" value = "Systematic review">
+                    {{ old('feature_review') == 'Systematic review'}}</input>
+                    <label class="form-check-label" for="feature_review1" >
+                        Systematic review
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review2"  value = "Systematic review and Snowballing">
+                    {{ old('feature_review') == 'Systematic review and Snowballing'}}</input>
+                    <label class="form-check-label" for="feature_review2">
+                        Systematic review and Snowballing
+                    </label>
+                </div> 
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="feature_review" id="feature_review3"  value= "Snowballing">
+                    {{ old('feature_review') == 'Snowballing'}}</input>
+                    <label class="form-check-label" for="feature_review3">
+                         Snowballing
+                    </label>
+                </div> 
+                
+                <div class="d-flex align-items-center">
+                    <button type="submit" class="btn btn-primary btn-sm ms-auto">{{ __('project/edit.edit')}}</button>
+                </div>
+            </form>
+            @include('layouts.footers.auth.footer')
+        </div>
+    </div>
 @endsection
-
-@push('scripts')
-	<!-- Insee o js e o css do quill -->
-	<link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
-	<script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
-
-	<script>
-
-		// Initialize o Quill faz dois "construtores" para os dois editores
-		document.addEventListener('DOMContentLoaded', function () {
-			var descriptionEditor = new Quill('#descriptionEditor', {
-				theme: 'snow'
-			});
-			var objectivesEditor = new Quill('#objectivesEditor', {
-				theme: 'snow'
-			});
-
-			// tentativa de carregar o conteúdo do editor com o valor do campo hidden
-			// atualmente não funciona, mas o valor do campo hidden é atualizado no submit
-			// apesar de passar com dados não salva no BD
-			document.getElementById('editProjectForm').addEventListener('submit', function () {
-				document.getElementById('descriptionInput').value = descriptionEditor.root.innerHTML;
-				document.getElementById('objectivesInput').value = objectivesEditor.root.innerHTML;
-			});
-		});
-	</script>
-@endpush


### PR DESCRIPTION
Após as modificações, foi inserido um campo de pesquisa no navbar que pesquisava projetos relacionados ao usuário, entretanto, considerei que essa modificação não faria sentido em um cenário em que o usuário ainda não estivesse logado no sistema. Ademais, o placeholder da barra de pesquisa na topnav também era muito confuso, não deixando claro que o campo era responsável por pesquisar projetos que contém determinada palavra-chave.
Assim, resolvi remover a barra de pesquisa da navbar, deixando apenas as informações restantes, e modifiquei o placeholder para deixar claro que a pesquisa estava relacionada aos projetos do usuário.