### PR TITLE
test(39): Teste automatizado - Planejamento > Extração de Dados

### DIFF
--- a/tests/selenium/python/pages/projects/planning/data_extraction.py
+++ b/tests/selenium/python/pages/projects/planning/data_extraction.py
@@ -1,0 +1,187 @@
+from selenium.webdriver.common.by import By
+from utils.config import BASE_URL
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+class DataExtractionPage:
+    URL = BASE_URL + 'projects'
+
+    def __init__(self, driver):
+        self.driver = driver
+
+    def load(self):
+        """
+        Carrega a página de projetos
+        """
+        self.driver.get(self.URL)
+
+    def open_project(self):
+        """
+        Clica no botão "Abrir" do primeiro projeto listado.
+        """
+        self.driver.find_element(By.XPATH, "//tbody/tr[1]/td[4]/div[1]/div[1]/a[1]").click()
+
+    def click_data_extraction_tab(self):
+        """
+        Acessa a aba Planejamento e depois 'Extração de Dados' dentro do projeto.
+        """
+        self.driver.find_element(By.LINK_TEXT, "Planejamento").click()
+        self.driver.find_element(By.LINK_TEXT, "Extração de Dados").click()
+
+    def scroll_to_element_and_click(self, xpath, timeout=10):
+        """
+        Aguarda até que o elemento esteja presente na página e faz scroll até ele e clica no botão de editar.
+        """
+        element = WebDriverWait(self.driver, timeout).until(
+        EC.presence_of_element_located((By.XPATH, xpath)))
+
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
+        self.driver.execute_script("arguments[0].click();", element)
+
+    def check_id_conflict_alert(self, timeout=5):
+        """
+        Verifica se o alerta de ID duplicado está visível na tela.
+        Retorna True se estiver, False se não estiver.
+        """
+        alert = WebDriverWait(self.driver, timeout).until(
+                EC.visibility_of_element_located((
+                    By.XPATH,
+                    "//*[contains(text(), 'Já existe uma questão com este ID')]"
+                ))
+            )
+        return alert.is_displayed()
+    
+    def edit_question_description(self, new_description):
+        """
+        Edita o campo de descrição da questão atualmente aberta no formulário.
+        """
+        description_input = WebDriverWait(self.driver, 10).until(
+        EC.element_to_be_clickable((
+            By.XPATH,
+            "/html[1]/body[1]/main[1]/div[1]/div[1]/div[2]/div[1]/div[1]/div[2]/div[8]/div[1]/div[1]/div[1]/div[2]/form[1]/div[1]/div[2]/input[1]"
+        )))
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", description_input)
+        self.driver.execute_script("arguments[0].click();", description_input)
+
+        description_input.clear()
+        description_input.send_keys(new_description)
+
+        save_button = WebDriverWait(self.driver, 10).until(
+        EC.element_to_be_clickable((By.XPATH, "//button[normalize-space()='Editar Pergunta']")))
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", save_button)
+        save_button.click()
+    
+    def get_form_data(self):
+        wait = WebDriverWait(self.driver, 15)
+
+        wait.until(lambda driver: driver.find_element(
+        By.XPATH, "//div[@class='form-group mt-3 d-flex flex-column gap-4']//input[@id='questionId']"
+    ).get_attribute('value') != "")
+
+        id_input = wait.until(EC.presence_of_element_located((
+        By.XPATH, "//div[@class='form-group mt-3 d-flex flex-column gap-4']//input[@id='questionId']"
+        )))
+
+        description_input = wait.until(EC.presence_of_element_located((
+            By.XPATH, "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div/div/div[2]/form/div/div[2]/input"
+        )))
+
+        type_input = wait.until(EC.presence_of_element_located((
+            By.XPATH, "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div/div/div[2]/form/div/div[3]/div/div/div/div"
+        )))
+
+        return {
+            "id": id_input.get_attribute("value").strip(),
+            "descricao": description_input.get_attribute("value").strip(),
+            "tipo": type_input.text.strip()
+        }
+    
+    def save_question(self):
+        """
+        Clica no botão 'Adicionar Pergunta' para salvar uma nova questão.
+        """
+        save_button = WebDriverWait(self.driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//button[normalize-space()='Adicionar Pergunta']"))
+        )
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", save_button)
+        save_button.click()
+
+    
+    def check_validation_error(self):
+        """
+        Verifica se aparece a mensagem 'Este campo é obrigatório' no formulário ao tentar enviar sem preencher os campos.
+        """
+        error_message = WebDriverWait(self.driver, 3).until(
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "//*[contains(text(), 'Este campo é obrigatório')]"
+            ))
+        )
+        return error_message.is_displayed()
+    
+    def fill_question_form(self, question_id, description, question_type):
+        id_input = WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH, "//div[@class='form-group mt-3 d-flex flex-column gap-4']//input[@id='questionId']"
+            ))
+        )
+        descricao_input = self.driver.find_element(
+            By.XPATH, "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div/div/div[2]/form/div/div[2]/input"
+        )
+        tipo_input = self.driver.find_element(
+            By.XPATH, "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div/div/div[2]/form/div/div[3]/div/div/div/div"
+        )
+
+        id_input.clear()
+        id_input.send_keys(question_id)
+        descricao_input.clear()
+        descricao_input.send_keys(description)
+        self.select_question_type(question_type)
+
+    def select_question_type(self, question_type):
+        """
+        Seleciona o tipo da questão no dropdown.
+        """
+        # Clica no dropdown para abrir as opções
+        dropdown_trigger = WebDriverWait(self.driver, 10).until(
+            EC.element_to_be_clickable((
+                By.XPATH,
+                "//div[@class='choices__item choices__item--selectable'][normalize-space()='Selecione um tipo']"
+            ))
+        )
+        dropdown_trigger.click()
+
+        # Aguarda as opções ficarem visíveis
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, "choices__list--dropdown"))
+        )
+
+        # Seleciona a opção correta
+        option = WebDriverWait(self.driver, 10).until(
+            EC.element_to_be_clickable((
+                By.XPATH,
+                f"//div[@class='choices__list choices__list--dropdown is-active']//div[contains(@class, 'choices__item') and normalize-space()=\"{question_type}\"]"
+            ))
+        )
+        self.driver.execute_script("arguments[0].scrollIntoView(true);", option)
+        option.click()
+        
+    def get_question_data_by_id(self):
+        id_xpath = "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div[2]/div/div/div/table/tbody/tr[1]/td[2]"
+        descricao_xpath = "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div[2]/div/div/div/table/tbody/tr[1]/td[3]"
+        tipo_xpath = "/html/body/main/div/div/div[2]/div/div/div[2]/div[8]/div/div[2]/div/div/div/table/tbody/tr[1]/td[4]"
+
+        id_element = self.driver.find_element(By.XPATH, id_xpath)
+        descricao_element = self.driver.find_element(By.XPATH, descricao_xpath)
+        tipo_element = self.driver.find_element(By.XPATH, tipo_xpath)
+
+        # Faz scroll até os elementos para garantir que estão visíveis
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", id_element)
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", descricao_element)
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", tipo_element)
+
+        return {
+            "id": id_element.text.strip(),
+            "descricao": descricao_element.text.strip(),
+            "tipo": tipo_element.text.strip()
+    }

--- a/tests/selenium/python/tests/test_data_extraction.py
+++ b/tests/selenium/python/tests/test_data_extraction.py
@@ -1,0 +1,91 @@
+from pages.projects.planning.data_extraction import DataExtractionPage
+from utils.web_functions import login
+from selenium.webdriver.common.by import By
+
+def test_validate_question_switch_updates_form(driver):
+    """
+    Verifica se ao clicar para editar uma questão e depois outra,
+    os dados no formulário realmente mudam, refletindo a segunda questão.
+    """
+    login(driver)
+
+    # Acessa a página do projeto
+    project_page = DataExtractionPage(driver)
+    project_page.load()
+
+    # Clica no botão "Abrir" do projeto
+    project_page.open_project()
+
+    # Abre aba de Planejamento
+    project_page.click_data_extraction_tab()
+
+    # Editar questão 1
+    project_page.scroll_to_element_and_click("//tbody/tr[1]/td[5]/div[1]/button[1]")
+    form_data_q1 = project_page.get_form_data()
+    print(f"Dados Q1: {form_data_q1}")
+
+    # Editar questão 2
+    project_page.scroll_to_element_and_click("//tbody/tr[2]/td[5]/div[1]/button[1]")
+    form_data_q2 = project_page.get_form_data()
+    print(f"Dados Q2: {form_data_q2}")
+
+    # Verifica se apareceu o alerta
+    assert project_page.check_id_conflict_alert(),"Alerta não apareceu"
+    # Validação: os dados devem ser diferentes
+    assert form_data_q1 != form_data_q2, "Os dados do formulário não mudaram ao trocar de questão"
+
+def test_create_question_with_missing_data(driver):
+    """
+    Testa se o sistema bloqueia o cadastro de uma questão sem preencher os campos obrigatórios.
+    """
+    login(driver)
+
+    project_page = DataExtractionPage(driver)
+    project_page.load()
+    project_page.open_project()
+    project_page.click_data_extraction_tab()
+
+    # Tenta salvar sem preencher nada
+    project_page.save_question()
+
+    # Check if validation errors are displayed
+    assert project_page.check_validation_error(), "O sistema permitiu cadastro sem preencher dados obrigatórios."
+
+def test_create_question_with_existing_id(driver):
+    """
+    Testa se o sistema impede a criação de uma questão com ID já existente.
+    """
+    login(driver)
+    project_page = DataExtractionPage(driver)
+    project_page.load()
+    project_page.open_project()
+    project_page.click_data_extraction_tab()
+
+    # Preencher com ID já existente
+    project_page.fill_question_form("Q1", "Tentando criar com ID duplicado", "Text")
+    project_page.save_question()
+
+    # Verificar se apareceu o alerta de conflito de ID
+    assert project_page.check_id_conflict_alert(), "O alerta de ID duplicado não apareceu."
+
+def test_edit_existing_question(driver):
+    """
+    Testa se é possível editar uma questão existente.
+    """
+   
+    login(driver)
+    project_page = DataExtractionPage(driver)
+    project_page.load()
+    project_page.open_project()
+    project_page.click_data_extraction_tab()
+
+    # Clica para editar a questão
+    project_page.scroll_to_element_and_click("//tbody/tr[2]/td[5]/div[1]/button[1]")
+
+    # Edita a descrição
+    project_page.edit_question_description("Descrição editada")
+    project_page.save_question()
+
+    # Valida se a descrição foi alterada na tabela
+    data = project_page.get_question_data_by_id()
+    assert data["descricao"] == "Descrição editada", "A descrição não foi atualizada corretamente."


### PR DESCRIPTION
Foram realizados os seguintes testes:

1. Validar se os campos são devidamente limpos e carregados corretamente ao clicar para editar uma questão e, em seguida, clicar para editar outra questão
1.1. **Bug localizado**: Ao clicar para editar a questão, os dados dessa questão aparecem corretamente no formulário. No entanto, se eu clicar para editar outra questão sem salvar antes, os dados exibidos continuam sendo da primeira questão, e não da nova que selecionei.
1.2. **Esperado**: Ao clicar para editar qualquer questão, os campos do formulário deveriam ser atualizados corretamente com os dados dessa questão.
1.3. **Correção**: Problema já está solucionado na develop, fazendo o reset das variáveis de forma correta.
3. Validar que não é possível criar uma questão sem os campos preenchidos
4. Validar que não é permitido criar questões com mesmo ID
5. Validar a edição de uma questão