### PR TITLE
Fix  67  traducoes incoerentes

### DIFF
--- a/lang/en/auth/login.php
+++ b/lang/en/auth/login.php
@@ -11,7 +11,7 @@ return [
     'reset_password_link' => 'here',
     'dont_have_account' => 'Don\'t have an account?',
     'sign_up_link' => 'Sign up',
-    'app_description' => '"Thoth :: Tool for SLR"',
+    'app_description' => 'Thoth :: Tool for SLR',
     'app_description_long' => 'Systematic reviews are a type of literature review that uses systematic methods to collect secondary data, critically appraise research studies, and synthesize studies.',
     'user_not_found' => 'This email address is not registered.',
     'failed' => 'The credentials do not match our records.',

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -25,7 +25,7 @@
                     </a>
                     <p>
                         {{ __("pages/terms.what_text") }}
-                        <a href="https://thoth-rsl.com">https://thoth-rsl.com</a>
+                        <a href="https://thoth-slr.com">https://thoth-slr.com</a>
                     </p>
 
                     <p>{{ __("pages/terms.objective") }}</p>


### PR DESCRIPTION
Ajuste nas traduções, em português a tradução está sem aspas e em inglês está com aspas>

![Imagem do WhatsApp de 2025-06-22 à(s) 18 53 41_84ff763e](https://github.com/user-attachments/assets/7c09c1c3-3f53-4f47-8b9d-0c6b55b2a6ec)

![Imagem do WhatsApp de 2025-06-22 à(s) 18 53 54_fdc5fb63](https://github.com/user-attachments/assets/8466d2ef-4e7b-42b2-8e99-ef53b5c454b4)


O pr corrige isso.