### PR TITLE
fix(13): Correção de idioma das rotas do superuser

### DIFF
--- a/resources/views/superuser/levels-show.blade.php
+++ b/resources/views/superuser/levels-show.blade.php
@@ -16,11 +16,11 @@
                         <input type="text" class="form-control" id="idGroup" value="{{ $level->id_level }}" readonly>
                     </div>
                     <div class="form-group">
-                        <label for="nameGroup">Nome</label>
+                        <label for="nameGroup">{{__("superuser/levels.group_name")}}</label>
                         <input type="text" class="form-control" id="nameGroup" value="{{ $level->level }}" readonly>
                     </div>
                     <div class="form-group">
-                        <label for="descriptionGroup">Descrição</label>
+                        <label for="descriptionGroup">{{__("superuser/levels.description")}}</label>
                         <input type="text" class="form-control" id="descriptionGroup" value="{{ $level->description }}" readonly>
                     </div>
                     <div class="d-flex justify-content-end mt-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -260,25 +260,25 @@ Route::prefix('project/{projectId}')->middleware(['auth', Localization::class])-
 });
 
 //SUPER USER ROUTES
-Route::middleware(['auth', 'role:SUPER_USER'])->group(function () {
-Route::get('/database-manager', [DatabaseManagerController::class, 'index'])->name('database-manager')->middleware('auth');
-Route::get('/user-manager', [UserManagerController::class, 'index'])->name('user-manager')->middleware('auth');
-Route::get('/users/{user}/edit', [UserManagerController::class, 'edit'])->name('user.edit');
-Route::post('/users/{user}', [UserManagerController::class, 'update'])->name('user.update');
-Route::get('/user/create', [UserManagerController::class, 'create'])->name('user.create');
-Route::post('/user', [UserManagerController::class, 'store'])->name('user.store');
-Route::get('/user/{user}/deactivate', [UserManagerController::class, 'deactivate'])->name('user.deactivate');
+Route::middleware(['auth', 'role:SUPER_USER', Localization::class])->group(function () {
+    Route::get('/database-manager', [DatabaseManagerController::class, 'index'])->name('database-manager')->middleware('auth');
+    Route::get('/user-manager', [UserManagerController::class, 'index'])->name('user-manager')->middleware('auth');
+    Route::get('/users/{user}/edit', [UserManagerController::class, 'edit'])->name('user.edit');
+    Route::post('/users/{user}', [UserManagerController::class, 'update'])->name('user.update');
+    Route::get('/user/create', [UserManagerController::class, 'create'])->name('user.create');
+    Route::post('/user', [UserManagerController::class, 'store'])->name('user.store');
+    Route::get('/user/{user}/deactivate', [UserManagerController::class, 'deactivate'])->name('user.deactivate');
 });
 
-Route::get('levels', [LevelController::class, 'index'])->name('levels.index')->middleware('auth');
-Route::get('levels/create', [LevelController::class, 'create'])->name('levels.create')->middleware('auth');
-Route::post('levels', [LevelController::class, 'store'])->name('levels.store')->middleware('auth');
-Route::get('levels/{level}', [LevelController::class, 'show'])->name('levels.show')->middleware('auth');
-Route::get('levels/{level}/edit', [LevelController::class, 'edit'])->name('levels.edit')->middleware('auth');
-Route::put('levels/{level}', [LevelController::class, 'update'])->name('levels.update')->middleware('auth');
-Route::post('levels/{level}', [LevelController::class, 'update'])->name('levels.update')->middleware('auth');
-Route::delete('levels/{level}', [LevelController::class, 'destroy'])->name('levels.destroy')->middleware('auth');
-Route::middleware(['auth', 'role:super-user'])->group(function () {
+Route::middleware(['auth', 'role:SUPER_USER', Localization::class])->group(function () {
+    Route::get('levels', [LevelController::class, 'index'])->name('levels.index')->middleware('auth');
+    Route::get('levels/create', [LevelController::class, 'create'])->name('levels.create')->middleware('auth');
+    Route::post('levels', [LevelController::class, 'store'])->name('levels.store')->middleware('auth');
+    Route::get('levels/{level}', [LevelController::class, 'show'])->name('levels.show')->middleware('auth');
+    Route::get('levels/{level}/edit', [LevelController::class, 'edit'])->name('levels.edit')->middleware('auth');
+    Route::put('levels/{level}', [LevelController::class, 'update'])->name('levels.update')->middleware('auth');
+    Route::post('levels/{level}', [LevelController::class, 'update'])->name('levels.update')->middleware('auth');
+    Route::delete('levels/{level}', [LevelController::class, 'destroy'])->name('levels.destroy')->middleware('auth');
     Route::resource('permissions', PermissionController::class);
 });
 


### PR DESCRIPTION
Após alguns PRs serem disponibilizados para merge, a branch develop apresentou alguns bugs no idioma das páginas do superuser, os quais não estavam sendo traduzidos para o idioma inglês. Com isso, foram feitas algumas modificações nas rotas do administrador para possibilitar a mudança de linguagem e, adicionalmente, alguns elementos da view `levels-show` foram atualizados para incluir os idiomas inclusos da plataforma.