### PR TITLE
Bug 73: Está sendo possível editar projetos e salvar eles com todos os campos vazios

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Project\ProjectStoreRequest;
+use App\Http\Requests\Project\ProjectUpdateRequest;
 use App\Http\Requests\Project\ProjectAddMemberRequest;
 use App\Http\Requests\Project\UpdateMemberLevelRequest;
 use App\Livewire\Planning\Overall\Domains;
@@ -127,8 +128,9 @@ class ProjectController extends Controller
     /**
      * Update the specified project in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(ProjectUpdateRequest $request, string $id)
     {
+        $request->validated();
         $project = Project::findOrFail($id);
         $user = Auth::user();
 

--- a/app/Http/Requests/Project/ProjectUpdateRequest.php
+++ b/app/Http/Requests/Project/ProjectUpdateRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Project;
+
+use App\Models\Project;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProjectUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+            'objectives' => 'required|string',
+            'copy_planning' => ['nullable', 'string', function ($attribute, $value, $fail) {
+                if ($value !== 'none' && !(Project::where('id_project', $value)->exists())) {
+                    $fail('The selected :attribute is invalid.');
+                }
+            }],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'title.required' => 'The title field is required.',
+            'title.string' => 'The title field must be a string.',
+            'title.max' => 'The title field must not be greater than 255 characters.',
+            'description.required' => 'The description field is required.',
+            'description.string' => 'The description field must be a string.',
+            'objectives.required' => 'The objectives field is required.',
+            'objectives.string' => 'The objectives field must be a string.',
+        ];
+    }
+} 


### PR DESCRIPTION
Eu identifiquei e corrigi uma inconsistência crítica no sistema onde era possível editar projetos com campos vazios. Implementei uma validação criando a classe ProjectUpdateRequest, garantindo que tanto a criação quanto a edição de projetos sigam as mesmas regras de validação. Essa mudança é importante pra manter a integridade dos dados e a consistência da experiência do usuário, evitando que projetos fiquem com informações incompletas ou inconsistentes no sistema. Além disso, mantive o campo feature_review apenas na criação, já que é uma característica que não deve ser alterada após o projeto ser iniciado.